### PR TITLE
(fix) Revert from helper to device

### DIFF
--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -15,7 +15,7 @@ class BermudaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for bermuda."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+    # CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):
         """Initialize."""

--- a/custom_components/bermuda/manifest.json
+++ b/custom_components/bermuda/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": ["bluetooth_adapters", "device_tracker"],
   "documentation": "https://github.com/agittins/bermuda",
-  "integration_type": "helper",
+  "integration_type": "device",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/agittins/bermuda/issues",
   "requirements": [],


### PR DESCRIPTION
- revert change from "helper" back to "device" integration_type.
- remove deprecated CONNECTION_CLASS config var.