### PR TITLE
chore: Versioning and release clean-ups

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,9 @@
+---
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+sort-direction: ascending
+
 categories:
   - title: ":boom: Breaking Changes"
     label: "breaking"
@@ -23,6 +29,28 @@ categories:
     labels:
       - "dependencies"
       - "build"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+      - "breaking-change"
+  minor:
+    labels:
+      - "minor"
+      - "new-feature"
+  patch:
+    labels:
+      - "bugfix"
+      - "chore"
+      - "ci"
+      - "dependencies"
+      - "documentation"
+      - "enhancement"
+      - "performance"
+      - "refactor"
+  default: patch
+
 template: |
   ## Changes
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
     env:
       BERMUDA_ROOT_DIR: "${{ github.workspace }}/custom_components/bermuda"
     steps:
@@ -22,15 +23,24 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set release version number in files
+        shell: bash
         run: |
-          sed -i '/VERSION.=./c\VERSION = "${{ github.ref_name }}"' "${{ env.BERMUDA_ROOT_DIR }}/const.py"
-          (jq '.version = "${{ github.ref_name }}"' "${{ env.BERMUDA_ROOT_DIR }}/manifest.json") > "${{ env.BERMUDA_ROOT_DIR }}/manifest.json.tmp"
+          version="${{ github.event.release.tag_name }}"
+          version="${version,,}"
+          version="${version#v}"
+          sed -i '/VERSION.=./c\VERSION = "${version}"' "${{ env.BERMUDA_ROOT_DIR }}/const.py"
+          (jq '.version = "${version}"' "${{ env.BERMUDA_ROOT_DIR }}/manifest.json") > "${{ env.BERMUDA_ROOT_DIR }}/manifest.json.tmp"
           mv "${{ env.BERMUDA_ROOT_DIR }}/manifest.json.tmp" "${{ env.BERMUDA_ROOT_DIR }}/manifest.json"
 
       - name: Zip the integration directory
         run: |
           cd "${{ env.BERMUDA_ROOT_DIR }}"
           zip bermuda.zip -r ./
+
+      - name: 🔏 Sign release package
+        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        with:
+          inputs: "${{ env.BERMUDA_ROOT_DIR }}/bermuda.zip"
 
       - name: "Upload the ZIP file to the release"
         uses: softprops/action-gh-release@v0.1.15

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -3,6 +3,11 @@
 NAME = "Bermuda BLE Trilateration"
 DOMAIN = "bermuda"
 DOMAIN_DATA = f"{DOMAIN}_data"
+# Version gets updated by github workflow during release.
+# The version in the repository should always be 0.0.0 to reflect
+# that the component has been checked out from git, not pulled from
+# an officially built release. HACS will use the git tag (or the zip file,
+# either way it works).
 VERSION = "0.0.0"
 
 ATTRIBUTION = "Data provided by http://jsonplaceholder.typicode.com/"

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -9,7 +9,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import ATTRIBUTION
 from .const import DOMAIN
 from .const import NAME
-from .const import VERSION
 
 if TYPE_CHECKING:
     from . import BermudaDataUpdateCoordinator
@@ -44,7 +43,8 @@ class BermudaEntity(CoordinatorEntity):
         return {
             "identifiers": {(DOMAIN, self._device.unique_id)},
             "name": self._device.prefname,
-            "model": VERSION,
+            # TODO: Could use this to indicate tracker type (IRK, iBeacon etc).
+            # "model": "some string",
             "manufacturer": NAME,
         }
 

--- a/custom_components/bermuda/manifest.json
+++ b/custom_components/bermuda/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/agittins/bermuda/issues",
   "requirements": [],
-  "version": "0.0.1"
+  "version": "0.0.0"
 }


### PR DESCRIPTION
- note in const that version is set by release only
- tweaks to release.yaml
- remove version info from entity.py since devices/entities don't need it.
- set repo version of manifest.json back to 0.0.0
- lifted some release settings from spook