### PR TITLE
fix: Clear version info from entity model number

### DIFF
--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -44,7 +44,7 @@ class BermudaEntity(CoordinatorEntity):
             "identifiers": {(DOMAIN, self._device.unique_id)},
             "name": self._device.prefname,
             # TODO: Could use this to indicate tracker type (IRK, iBeacon etc).
-            # "model": "some string",
+            "model": None,
             "manufacturer": NAME,
         }
 


### PR DESCRIPTION
- clear model info for existing devices (previously set to version / 0.0.0, which is confusing and not helpful).