### PR TITLE
(feat) Per-proxy distance sensors

### DIFF
--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -13,6 +13,8 @@ from .const import CONF_DEVTRACK_TIMEOUT
 from .const import CONF_MAX_RADIUS
 from .const import CONF_REF_POWER
 from .const import DEFAULT_ATTENUATION
+from .const import DEFAULT_DEVTRACK_TIMEOUT
+from .const import DEFAULT_MAX_RADIUS
 from .const import DEFAULT_REF_POWER
 from .const import DOMAIN
 from .const import NAME
@@ -126,11 +128,13 @@ class BermudaOptionsFlowHandler(config_entries.OptionsFlow):
         data_schema = {
             vol.Required(
                 CONF_MAX_RADIUS,
-                default=self.options.get(CONF_MAX_RADIUS, 3.0),
+                default=self.options.get(CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS),
             ): vol.Coerce(float),
             vol.Required(
                 CONF_DEVTRACK_TIMEOUT,
-                default=self.options.get(CONF_DEVTRACK_TIMEOUT, 30),
+                default=self.options.get(
+                    CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT
+                ),
             ): vol.Coerce(int),
             vol.Required(
                 CONF_ATTENUATION,

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -27,6 +27,9 @@ DEVICE_TRACKER = "device_tracker"
 # PLATFORMS = [BINARY_SENSOR, SENSOR, SWITCH]
 PLATFORMS = [SENSOR, DEVICE_TRACKER]
 
+# Signal names we are using:
+SIGNAL_DEVICE_NEW = f"{DOMAIN}-device-new"
+
 DOCS = {}
 
 ADVERT_FRESHTIME = 2.5
@@ -38,6 +41,11 @@ ADVERT_FRESHTIME = 2.5
 HIST_KEEP_COUNT = (
     10  # How many old timestamps, rssi, etc to keep for each device/scanner pairing.
 )
+
+# Config entry DATA entries
+
+CONFDATA_SCANNERS = "scanners"
+DOCS[CONFDATA_SCANNERS] = "Persisted set of known scanners (proxies)"
 
 # Configuration and options
 

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -42,6 +42,12 @@ class BermudaDeviceTracker(BermudaEntity, BaseTrackerEntity):
     _attr_name = None
 
     @property
+    def unique_id(self):
+        """ "Uniquely identify this sensor so that it gets stored in the entity_registry,
+        and can be maintained / renamed etc by the user"""
+        return self._device.unique_id
+
+    @property
     def extra_state_attributes(self) -> Mapping[str, str]:
         """Return extra state attributes for this device."""
         return {"scanner": self._device.area_scanner, "area": self._device.area_name}

--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -34,6 +34,16 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "distance": {
+        "name": "Distance"
+      },
+      "area": {
+        "name": "Area"
+      }
+    }
+  },
   "services": {
     "dump_devices": {
       "name": "Dump Devices",


### PR DESCRIPTION
- Added a distance sensor for each proxy on each tracked device.
- fixed defaults for radius and timeout not applying correctly
- fixed initialisation of sensors at system start, they are now created via callback from the data processor.
- Implemented method for sensor platform to positively indicate the sensors were created (`sensor_created`)
- Perform full re-scan of restored scanners to catch any changes since last save.
- initialise zone as STATE_UNAVAILABLE
- fix unique-id mappings and pin them to mac address more directly instead of inheriting from the parent classes.
- implement `unit_of_measurements` to get distances appearing as graphable more cleanly than the native property did.