### PR TITLE
Fix liniting error in pre-commit checks

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -3,7 +3,7 @@ Custom integration to integrate Bermuda BLE Trilateration with Home Assistant.
 
 For more details about this integration, please refer to
 https://github.com/agittins/bermuda
-"""
+""" # fmt: skip
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -3,7 +3,7 @@ Custom integration to integrate Bermuda BLE Trilateration with Home Assistant.
 
 For more details about this integration, please refer to
 https://github.com/agittins/bermuda
-""" # fmt: skip
+"""  # fmt: skip
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/bermuda/binary_sensor.py
+++ b/custom_components/bermuda/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Binary sensor platform for Bermuda BLE Trilateration."""
+"""Binary sensor platform for Bermuda BLE Trilateration.""" # fmt: skip
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
 from .const import BINARY_SENSOR

--- a/custom_components/bermuda/binary_sensor.py
+++ b/custom_components/bermuda/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Binary sensor platform for Bermuda BLE Trilateration.""" # fmt: skip
+"""Binary sensor platform for Bermuda BLE Trilateration."""  # fmt: skip
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
 from .const import BINARY_SENSOR

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -1,4 +1,4 @@
-"""Adds config flow for Bermuda BLE Trilateration."""  #fmt: skip
+"""Adds config flow for Bermuda BLE Trilateration."""  # fmt: skip
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import bluetooth

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -1,4 +1,4 @@
-"""Adds config flow for Bermuda BLE Trilateration."""
+"""Adds config flow for Bermuda BLE Trilateration."""  #fmt: skip
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import bluetooth

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -56,9 +56,7 @@ CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS = "max_area_radius", 20
 DOCS[CONF_MAX_RADIUS] = "For simple area-detection, max radius from receiver"
 
 CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT = "devtracker_nothome_timeout", 30
-DOCS[
-    CONF_DEVTRACK_TIMEOUT
-] = "Timeout in seconds for setting devices as `Not Home` / `Away`."
+DOCS[CONF_DEVTRACK_TIMEOUT] = "Timeout in seconds for setting devices as `Not Home` / `Away`."
 
 CONF_ATTENUATION, DEFAULT_ATTENUATION = "attenuation", 3
 DOCS[CONF_ATTENUATION] = "Factor for environmental signal attenuation."

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -1,4 +1,4 @@
-"""Constants for Bermuda BLE Trilateration."""
+"""Constants for Bermuda BLE Trilateration."""  # fmt: skip
 # Base component constants
 NAME = "Bermuda BLE Trilateration"
 DOMAIN = "bermuda"

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -56,7 +56,7 @@ CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS = "max_area_radius", 20
 DOCS[CONF_MAX_RADIUS] = "For simple area-detection, max radius from receiver"
 
 CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT = "devtracker_nothome_timeout", 30
-DOCS[CONF_DEVTRACK_TIMEOUT] = "Timeout in seconds for setting devices as `Not Home` / `Away`."
+DOCS[CONF_DEVTRACK_TIMEOUT] = "Timeout in seconds for setting devices as `Not Home` or `Away`."
 
 CONF_ATTENUATION, DEFAULT_ATTENUATION = "attenuation", 3
 DOCS[CONF_ATTENUATION] = "Factor for environmental signal attenuation."

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -56,7 +56,7 @@ CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS = "max_area_radius", 20
 DOCS[CONF_MAX_RADIUS] = "For simple area-detection, max radius from receiver"
 
 CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT = "devtracker_nothome_timeout", 30
-DOCS[CONF_DEVTRACK_TIMEOUT] = "Timeout in seconds for setting devices as `Not Home` or `Away`."
+DOCS[CONF_DEVTRACK_TIMEOUT] = ( "Timeout in seconds for setting devices as `Not Home` / `Away`." )
 
 CONF_ATTENUATION, DEFAULT_ATTENUATION = "attenuation", 3
 DOCS[CONF_ATTENUATION] = "Factor for environmental signal attenuation."

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -56,7 +56,9 @@ CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS = "max_area_radius", 20
 DOCS[CONF_MAX_RADIUS] = "For simple area-detection, max radius from receiver"
 
 CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT = "devtracker_nothome_timeout", 30
-DOCS[CONF_DEVTRACK_TIMEOUT] = ( "Timeout in seconds for setting devices as `Not Home` / `Away`." )
+DOCS[CONF_DEVTRACK_TIMEOUT] = (
+    "Timeout in seconds for setting devices as `Not Home` / `Away`."
+)
 
 CONF_ATTENUATION, DEFAULT_ATTENUATION = "attenuation", 3
 DOCS[CONF_ATTENUATION] = "Factor for environmental signal attenuation."

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -1,4 +1,4 @@
-"""Create device_tracker entities for Bermuda devices"""  #fmt: skip
+"""Create device_tracker entities for Bermuda devices"""  # fmt: skip
 from __future__ import annotations
 
 import logging

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -1,4 +1,4 @@
-"""Create device_tracker entities for Bermuda devices""" #fmt: skip
+"""Create device_tracker entities for Bermuda devices"""  #fmt: skip
 from __future__ import annotations
 
 import logging

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -1,4 +1,4 @@
-"""Create device_tracker entities for Bermuda devices"""
+"""Create device_tracker entities for Bermuda devices""" #fmt: skip
 from __future__ import annotations
 
 import logging

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -1,4 +1,4 @@
-"""BermudaEntity class""" # fmt: skip
+"""BermudaEntity class"""  # fmt: skip
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -1,4 +1,4 @@
-"""BermudaEntity class"""
+"""BermudaEntity class""" # fmt: skip
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for Bermuda BLE Trilateration."""  #fmt: skip
+"""Sensor platform for Bermuda BLE Trilateration."""  # fmt: skip
 from collections.abc import Mapping
 from typing import Any
 

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -1,4 +1,4 @@
-"""Sensor platform for Bermuda BLE Trilateration."""
+"""Sensor platform for Bermuda BLE Trilateration."""  #fmt: skip
 from collections.abc import Mapping
 from typing import Any
 

--- a/custom_components/bermuda/switch.py
+++ b/custom_components/bermuda/switch.py
@@ -1,4 +1,4 @@
-"""Switch platform for Bermuda BLE Trilateration."""
+"""Switch platform for Bermuda BLE Trilateration."""  #fmt: skip
 from homeassistant.components.switch import SwitchEntity
 
 from .const import DEFAULT_NAME

--- a/custom_components/bermuda/switch.py
+++ b/custom_components/bermuda/switch.py
@@ -1,4 +1,4 @@
-"""Switch platform for Bermuda BLE Trilateration."""  #fmt: skip
+"""Switch platform for Bermuda BLE Trilateration."""  # fmt: skip
 from homeassistant.components.switch import SwitchEntity
 
 from .const import DEFAULT_NAME

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Global fixtures for Bermuda BLE Trilateration integration."""
+"""Global fixtures for Bermuda BLE Trilateration integration."""  # fmt: skip
 from unittest.mock import patch
 
 import pytest

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,4 +1,4 @@
-"""Constants for Bermuda BLE Trilateration tests."""
+"""Constants for Bermuda BLE Trilateration tests."""  # fmt: skip
 # AJG: We don't use these vars in our flow. TODO: Add some we _do_ use!
 # from custom_components.bermuda.const import (
 #    CONF_PASSWORD,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Test Bermuda BLE Trilateration config flow."""
+"""Test Bermuda BLE Trilateration config flow."""  # fmt: skip
 from unittest.mock import patch
 
 import pytest

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,4 @@
-"""Test Bermuda BLE Trilateration setup process."""
+"""Test Bermuda BLE Trilateration setup process."""  # fmt: skip
 import pytest
 from custom_components.bermuda import (
     async_reload_entry,

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,4 +1,4 @@
-"""Test Bermuda BLE Trilateration switch."""
+"""Test Bermuda BLE Trilateration switch."""  # fmt: skip
 from unittest.mock import call
 from unittest.mock import patch
 


### PR DESCRIPTION
It seems this may be due to an incompatibility between black and reorder-python-imports
https://github.com/psf/black/issues/4175

I have added the following to the end of the first comment in the files affected:
  # fmt: skip

Pre-commit is now passing tests

Addresses issue #22 