### PR TITLE
Chore: Replace reorder-imports with isort

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Python modules
         run: |
-          pip install --constraint=.github/workflows/constraints.txt pre-commit black flake8 reorder-python-imports
+          pip install --constraint=.github/workflows/constraints.txt pre-commit black flake8 isort
 
       - name: Run pre-commit on all files
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ config/blueprint*
 config/.HA_VERSION
 config/configuration.yaml
 config/known_devices.yaml
+
+node_modules/.cache*

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,4 @@
+[settings]
+add_imports=from __future__ import annotations
+force_single_line=true
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,8 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: local
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
     hooks:
       - id: black
         name: black
@@ -14,6 +15,8 @@ repos:
         language: system
         types: [python]
         require_serial: true
+  - repo: local
+    hooks:
       - id: flake8
         name: flake8
         entry: flake8
@@ -25,6 +28,6 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.2
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml
@@ -20,12 +20,10 @@ repos:
         language: system
         types: [python]
         require_serial: true
-      - id: reorder-python-imports
-        name: Reorder python imports
-        entry: reorder-python-imports
-        language: system
-        types: [python]
-        args: [--application-directories=custom_components]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.2
     hooks:

--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,1 +1,3 @@
 """Dummy init so that pytest works."""
+
+from __future__ import annotations

--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -13,10 +13,10 @@ from datetime import timedelta
 
 import voluptuous as vol
 from homeassistant.components import bluetooth
+from homeassistant.components.bluetooth import MONOTONIC_TIME
 from homeassistant.components.bluetooth import BluetoothChange
 from homeassistant.components.bluetooth import BluetoothScannerDevice
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
-from homeassistant.components.bluetooth import MONOTONIC_TIME
 from homeassistant.components.bluetooth.active_update_coordinator import (
     PassiveBluetoothDataUpdateCoordinator,
 )
@@ -24,10 +24,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_HOME
 from homeassistant.const import STATE_NOT_HOME
 from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.core import callback
 from homeassistant.core import Config
 from homeassistant.core import HomeAssistant
 from homeassistant.core import SupportsResponse
+from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import area_registry
 from homeassistant.helpers import config_validation as cv

--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -4,6 +4,7 @@ Custom integration to integrate Bermuda BLE Trilateration with Home Assistant.
 For more details about this integration, please refer to
 https://github.com/agittins/bermuda
 """
+
 from __future__ import annotations
 
 import asyncio

--- a/custom_components/bermuda/binary_sensor.py
+++ b/custom_components/bermuda/binary_sensor.py
@@ -1,4 +1,6 @@
 """Binary sensor platform for Bermuda BLE Trilateration."""
+from __future__ import annotations
+
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
 from .const import BINARY_SENSOR

--- a/custom_components/bermuda/binary_sensor.py
+++ b/custom_components/bermuda/binary_sensor.py
@@ -1,4 +1,5 @@
 """Binary sensor platform for Bermuda BLE Trilateration."""
+
 from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorEntity

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -1,4 +1,6 @@
 """Adds config flow for Bermuda BLE Trilateration."""
+from __future__ import annotations
+
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components import bluetooth

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -1,4 +1,5 @@
 """Adds config flow for Bermuda BLE Trilateration."""
+
 from __future__ import annotations
 
 import voluptuous as vol

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -1,4 +1,5 @@
 """Constants for Bermuda BLE Trilateration."""
+
 # Base component constants
 from __future__ import annotations
 
@@ -58,9 +59,9 @@ CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS = "max_area_radius", 20
 DOCS[CONF_MAX_RADIUS] = "For simple area-detection, max radius from receiver"
 
 CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT = "devtracker_nothome_timeout", 30
-DOCS[
-    CONF_DEVTRACK_TIMEOUT
-] = "Timeout in seconds for setting devices as `Not Home` / `Away`."
+DOCS[CONF_DEVTRACK_TIMEOUT] = (
+    "Timeout in seconds for setting devices as `Not Home` / `Away`."  # fmt: skip
+)
 
 CONF_ATTENUATION, DEFAULT_ATTENUATION = "attenuation", 3
 DOCS[CONF_ATTENUATION] = "Factor for environmental signal attenuation."

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -1,5 +1,7 @@
 """Constants for Bermuda BLE Trilateration."""
 # Base component constants
+from __future__ import annotations
+
 NAME = "Bermuda BLE Trilateration"
 DOMAIN = "bermuda"
 DOMAIN_DATA = f"{DOMAIN}_data"

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -1,4 +1,5 @@
 """Create device_tracker entities for Bermuda devices"""
+
 from __future__ import annotations
 
 import logging

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -1,4 +1,5 @@
 """BermudaEntity class"""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -1,4 +1,6 @@
 """Sensor platform for Bermuda BLE Trilateration."""
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Any
 
@@ -6,8 +8,8 @@ from homeassistant import config_entries
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import UnitOfLength
-from homeassistant.core import callback
 from homeassistant.core import HomeAssistant
+from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for Bermuda BLE Trilateration."""
+
 from __future__ import annotations
 
 from collections.abc import Mapping

--- a/custom_components/bermuda/switch.py
+++ b/custom_components/bermuda/switch.py
@@ -1,4 +1,6 @@
 """Switch platform for Bermuda BLE Trilateration."""
+from __future__ import annotations
+
 from homeassistant.components.switch import SwitchEntity
 
 from .const import DEFAULT_NAME

--- a/custom_components/bermuda/switch.py
+++ b/custom_components/bermuda/switch.py
@@ -1,4 +1,5 @@
 """Switch platform for Bermuda BLE Trilateration."""
+
 from __future__ import annotations
 
 from homeassistant.components.switch import SwitchEntity

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,6 @@ pytest-asyncio
 pytest-homeassistant-custom-component
 #==0.13.50
 pre-commit
-reorder-python-imports
+isort
 pyserial-asyncio==0.6
 pyserial==3.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,5 +4,6 @@ pytest-homeassistant-custom-component
 #==0.13.50
 pre-commit
 isort
+black==24.2.0
 pyserial-asyncio==0.6
 pyserial==3.5

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,3 @@
 """Tests for Bermuda BLE Trilateration integration."""
+
+from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Global fixtures for Bermuda BLE Trilateration integration."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 """Global fixtures for Bermuda BLE Trilateration integration."""
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/const.py
+++ b/tests/const.py
@@ -7,4 +7,6 @@
 #    CONF_USERNAME,
 # )
 # MOCK_CONFIG = {CONF_USERNAME: "test_username", CONF_PASSWORD: "test_password"}
+from __future__ import annotations
+
 MOCK_CONFIG = {}

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,4 +1,5 @@
 """Constants for Bermuda BLE Trilateration tests."""
+
 # AJG: We don't use these vars in our flow. TODO: Add some we _do_ use!
 # from custom_components.bermuda.const import (
 #    CONF_PASSWORD,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,25 +1,18 @@
 """Test Bermuda BLE Trilateration config flow."""
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import pytest
-from custom_components.bermuda.const import (
-    BINARY_SENSOR,
-)
-from custom_components.bermuda.const import (
-    DOMAIN,
-)
-from custom_components.bermuda.const import (
-    PLATFORMS,
-)
-from custom_components.bermuda.const import (
-    SENSOR,
-)
-from custom_components.bermuda.const import (
-    SWITCH,
-)
 from homeassistant import config_entries
 from homeassistant import data_entry_flow
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bermuda.const import BINARY_SENSOR
+from custom_components.bermuda.const import DOMAIN
+from custom_components.bermuda.const import PLATFORMS
+from custom_components.bermuda.const import SENSOR
+from custom_components.bermuda.const import SWITCH
 
 from .const import MOCK_CONFIG
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Bermuda BLE Trilateration config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,22 +1,15 @@
 """Test Bermuda BLE Trilateration setup process."""
+from __future__ import annotations
+
 import pytest
-from custom_components.bermuda import (
-    async_reload_entry,
-)
-from custom_components.bermuda import (
-    async_setup_entry,
-)
-from custom_components.bermuda import (
-    async_unload_entry,
-)
-from custom_components.bermuda import (
-    BermudaDataUpdateCoordinator,
-)
-from custom_components.bermuda.const import (
-    DOMAIN,
-)
 from homeassistant.exceptions import ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bermuda import BermudaDataUpdateCoordinator
+from custom_components.bermuda import async_reload_entry
+from custom_components.bermuda import async_setup_entry
+from custom_components.bermuda import async_unload_entry
+from custom_components.bermuda.const import DOMAIN
 
 from .const import MOCK_CONFIG
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 """Test Bermuda BLE Trilateration setup process."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,4 +1,5 @@
 """Test Bermuda BLE Trilateration switch."""
+
 from __future__ import annotations
 
 from unittest.mock import call

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,23 +1,18 @@
 """Test Bermuda BLE Trilateration switch."""
+from __future__ import annotations
+
 from unittest.mock import call
 from unittest.mock import patch
 
-from custom_components.bermuda import (
-    async_setup_entry,
-)
-from custom_components.bermuda.const import (
-    DEFAULT_NAME,
-)
-from custom_components.bermuda.const import (
-    DOMAIN,
-)
-from custom_components.bermuda.const import (
-    SWITCH,
-)
 from homeassistant.components.switch import SERVICE_TURN_OFF
 from homeassistant.components.switch import SERVICE_TURN_ON
 from homeassistant.const import ATTR_ENTITY_ID
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bermuda import async_setup_entry
+from custom_components.bermuda.const import DEFAULT_NAME
+from custom_components.bermuda.const import DOMAIN
+from custom_components.bermuda.const import SWITCH
 
 from .const import MOCK_CONFIG
 


### PR DESCRIPTION
Includes WIP on supporting passive bluetooth data updates (because lazy).

- replaces reorder-imports with isort, see https://github.com/psf/black/issues/4175
- (ri is stubbornly extending beyond its stated singular goal and douchebaggery is prohibiting fixing it)
- big thanks to @jaymunro for tracking down the core issue at https://github.com/agittins/bermuda/pull/114
