### PR TITLE
fix: Add timeout logic for distance measurements

### DIFF
--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -35,6 +35,16 @@ PLATFORMS = [SENSOR, DEVICE_TRACKER]
 # Signal names we are using:
 SIGNAL_DEVICE_NEW = f"{DOMAIN}-device-new"
 
+DISTANCE_TIMEOUT = 30  # seconds to wait before marking a sensor distance measurement
+# as unknown/none/stale/away. Separate from device_tracker.
+
+UPDATE_INTERVAL = 1.05  # Seconds between bluetooth data processing cycles
+# Note: this is separate from the CONF_UPDATE_INTERVAL which allows the
+# user to indicate how often sensors should update. We need to check bluetooth
+# stats often to get good responsiveness for beacon approaches and to make
+# the smoothing algo's easier. But sensor updates should bear in mind how
+# much data it generates for databases and browser traffic.
+
 # Beacon-handling constants. Source devices are tracked by MAC-address and are the
 # originators of beacon-like data. We then create a "meta-device" for the beacon's
 # uuid. Other non-static-mac protocols should use this method as well, by adding their
@@ -77,9 +87,9 @@ DOCS[CONF_ATTENUATION] = "Factor for environmental signal attenuation."
 CONF_REF_POWER, DEFAULT_REF_POWER = "ref_power", -55.0
 DOCS[CONF_REF_POWER] = "Default RSSI for signal at 1 metre."
 
-CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL = "update_interval", 1.1
+CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL = "update_interval", 10
 DOCS[CONF_UPDATE_INTERVAL] = (
-    "How often to update bluetooth stats, in seconds. 1.1 is pretty good, I reckon."  # fmt: skip
+    "Maximum time between sensor updates in seconds. Smaller intervals means more data, bigger database."  # fmt: skip
 )
 
 CONF_SMOOTHING_SAMPLES, DEFAULT_SMOOTHING_SAMPLES = "smoothing_samples", 20

--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -23,7 +23,7 @@
         "data": {
           "max_area_radius": "Max radius in metres for simple AREA detection",
           "devtracker_nothome_timeout": "Timeout in seconds to consider a device as `Not Home`.",
-          "update_interval": "How often in seconds to update bluetooth data",
+          "update_interval": "How often in seconds to update sensor readings data",
           "attenuation": "Environment attenuation factor for distance calculation.",
           "ref_power": "Default rssi at 1 metre distance.",
           "configured_devices": "List of Bluetooth devices to specifically create tracking entities for.",
@@ -32,7 +32,7 @@
         "data_description": {
           "max_area_radius": "In the simple `AREA` feature, a device will be marked as being in the AREA of it's closest receiver, if inside this radius. If you set it small, devices will go to `unknown` between receivers, but if large devices will always appear as in their closest Area.",
           "devtracker_nothome_timeout": "How quickly to mark device_tracker entities as `not_home` after we stop seeing advertisements. 30 seconds or more is probably good.",
-          "update_interval": "Around 1 second will give good update freshness, but might slow your system and grow your database size.",
+          "update_interval": "Distance readings indicating approaches will still trigger immediately, but increasing distances will be rate limited by this to reduce how much your database grows.",
           "smoothing_samples": "How many samples to average distance smoothing. Bigger numbers make for slower distance increases. 10 or 20 seems good."
         }
       }


### PR DESCRIPTION
- Distances older than DISTANCE_TIMEOUT are regarded as too old, and device is marked as out of range by setting rssi_distance to None.
- Filter history is cleared for devices that have gone out of range
- Initial steps to apply rate-limiting for sensor values.
- Made backend update_interval back to constant (rather than config) and 1.05 seconds.