### PR TITLE
fix: Fix updates for local USB scan entries

### DIFF
--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -48,7 +48,7 @@ class BermudaEntity(CoordinatorEntity):
         self.bermuda_last_state: Any = 0
         self.bermuda_last_stamp: int = 0
 
-    def _cached_ratelimit(self, statevalue: Any, FastFalling=True, FastRising=False):
+    def _cached_ratelimit(self, statevalue: Any, fast_falling=True, fast_rising=False):
         """Uses the CONF_UPDATE_INTERVAL and other logic to return either the given statevalue
         or an older, cached value. Helps to reduce excess sensor churn without compromising latency.
 
@@ -62,8 +62,10 @@ class BermudaEntity(CoordinatorEntity):
             )  # Cache is stale
             or (self.bermuda_last_state is None)  # Nothing compares to you.
             or (statevalue is None)  # or you.
-            or (FastFalling and statevalue < self.bermuda_last_state)  # (like Distance)
-            or (FastRising and statevalue > self.bermuda_last_state)  # (like RSSI)
+            or (
+                fast_falling and statevalue < self.bermuda_last_state
+            )  # (like Distance)
+            or (fast_rising and statevalue > self.bermuda_last_state)  # (like RSSI)
         ):
             # Publish the new value and update cache
             self.bermuda_last_stamp = nowstamp

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -171,7 +171,7 @@ class BermudaSensorRssi(BermudaSensor):
     @property
     def native_value(self):
         return self._cached_ratelimit(
-            self._device.area_rssi, FastFalling=False, FastRising=True
+            self._device.area_rssi, fast_falling=False, fast_rising=True
         )
 
     @property


### PR DESCRIPTION
- fix: Fix updates for local USB scan entries
    - There was a bug where the device.scanner data wasn't being updated if the scanner was no longer providing (caching) an advertisement for that device. This mainly showed up on local usb bluetooth dongles, because I think BlueZ would expunge the advert history more quickly than we timeout a distance reading (30 sec by default). The result would be that out-of-range devices would snap to the last distance recorded by the usb adaptor, since we never cleaned it up previously. This might also result in other fixes but I haven't seen cases where proxies would drop advert caches.
    
    - Removed have_new_stamp and refactored it to be indicated by new_stamp being None. Preserved into self.new_stamp and split the calculate_data() step out of t
he update_advertisement() step.

- linting: Changed FastFalling/Rising to snake_case.