### PR TITLE
feat: iOS / iPhone / Private BLE Device / IRK Support!

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -1010,7 +1010,14 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
             if device.last_seen > metadev.last_seen:
                 metadev.last_seen = device.last_seen
             elif device.last_seen < metadev.last_seen:
-                _LOGGER.warning("Using freshest advert but it's still too old!")
+                # FIXME: This is showing up for some people (see https://github.com/agittins/bermuda/issues/138)
+                # but I can't see why. Downgrading to debug since it doesn't seem to affect ops, and adding
+                # params so I can perhaps get more info later.
+                _LOGGER.debug(
+                    "Using freshest advert from %s for %s but it's still too old!",
+                    device.name,
+                    metadev.name,
+                )
             # else there's no newer advert
 
             if device.address not in metadev.beacon_sources:

--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -1128,7 +1128,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
             for dev_entry in self.hass.data["device_registry"].devices.data.values():
                 for dev_connection in dev_entry.connections:
                     if dev_connection[0] in ["mac", "bluetooth"]:
-                        found_address = dev_connection[1].upper()
+                        found_address = format_mac(dev_connection[1])
                         if found_address in addresses:
                             scandev = self._get_device(found_address)
                             if scandev is None:
@@ -1136,6 +1136,8 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
                                 _LOGGER.debug("New Scanner: %s", found_address)
                                 update_scannerlist = True
                                 scandev = self._get_or_create_device(found_address)
+                            # Found the device entry and have created our scannerdevice,
+                            # now update any fields that might be new from the device reg:
                             scandev_orig = scandev
                             scandev.area_id = dev_entry.area_id
                             scandev.entry_id = dev_entry.id
@@ -1152,6 +1154,8 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
                                     scandev.name,
                                 )
                             scandev.is_scanner = True
+                            # If the scanner data we loaded from our saved data appears
+                            # out of date, trigger a full rescan of seen scanners.
                             if scandev_orig != scandev:
                                 # something changed, let's update the saved list.
                                 _LOGGER.debug(

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -32,6 +32,9 @@ DEVICE_TRACKER = "device_tracker"
 # PLATFORMS = [BINARY_SENSOR, SENSOR, SWITCH]
 PLATFORMS = [SENSOR, DEVICE_TRACKER]
 
+# Should probably retreive this from the component, but it's in "DOMAIN" *shrug*
+DOMAIN_PRIVATE_BLE_DEVICE = "private_ble_device"
+
 # Signal names we are using:
 SIGNAL_DEVICE_NEW = f"{DOMAIN}-device-new"
 
@@ -55,6 +58,12 @@ BEACON_IBEACON_SOURCE: Final = (
 )
 BEACON_IBEACON_DEVICE: Final = (
     "beacon device"  # The meta-device created to track the beacon
+)
+BEACON_PRIVATE_BLE_SOURCE: Final = (
+    "private_ble_src"  # current (random) MAC of a private ble device
+)
+BEACON_PRIVATE_BLE_DEVICE: Final = (
+    "private_ble_device"  # meta-device create to track private ble device
 )
 
 DOCS = {}

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
     created_devices = []  # list of already-created devices
 
     @callback
-    def device_new(address: str, scanners: [str]) -> None:
+    def device_new(address: str, scanners: list[str]) -> None:
         """Create entities for newly-found device
 
         Called from the data co-ordinator when it finds a new device that needs

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import BermudaDataUpdateCoordinator
 from .const import BEACON_IBEACON_DEVICE
+from .const import BEACON_PRIVATE_BLE_DEVICE
 from .const import DOMAIN
 from .const import SIGNAL_DEVICE_NEW
 from .entity import BermudaEntity
@@ -122,7 +123,10 @@ class BermudaSensor(BermudaEntity, SensorEntity):
     @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:
         current_mac = self._device.address
-        if self._device.beacon_type == BEACON_IBEACON_DEVICE:
+        if self._device.beacon_type in [
+            BEACON_IBEACON_DEVICE,
+            BEACON_PRIVATE_BLE_DEVICE,
+        ]:
             if len(self._device.beacon_sources) > 0:
                 current_mac = self._device.beacon_sources[0]
             else:


### PR DESCRIPTION
- 🚀 feat: iOS / iPhone Support with IRK #135 
    
    - Integrated with the `Private BLE Device` integration. Any devices set up in Private BLE will automatically be configured as Bermuda trackers as well.
    
    - 🐛 Fixed error if no devices are saved for setup (ie, CONF_DEVICES is empty) as may happen if one uses *only* Private BLE Devices.
    
    - Added refresh calls to device registry listener
    
    - Improved some mac_format calls by forcing .lower(), since some "addresses" like private ble will not match a MAC-based pattern.
    
    - Fixed new_device signal dispatcher to use full list of devices and check for create_sensor rather than scanning CONF_DEVICES
    
    - Added Private BLE Devices to the iBeacon code, so both are treated as "meta-devices" in that they have data that is provided via the MAC address, but is not "of" the mac address.
    
    - Fixed case when _refresh_scanners gathers addresses.
    
    - Updated device_info in entity.py to ensure entities tied to private_ble devices get linked to those device_registry entries.

- fix: typedef for device_new callback

- 🚤 feat: Update areas in realtime if scanners are moved improves #137 fix.
    
    - If an esphome or other scanner/proxy device has its "area" modified, we immediately update the Areas without requiring a reload or restart.
    
    - A little comment-linting.

- 🐛 fix: matching of scanner IDs loaded from data (stuck area) fixes #137 
    
    - scanner entries were being saved in data with "our default lower-case" form, but when loading was comparing them to uppercased. This was causing the data stored values to prevent correct loading, so changing the area of a scanner never got applied.

- 📯  chore: Downgraged ibeacon stale source msg to debug
    
    - was set to warning, and #138 shows people are getting this on their systems. I'm not sure why, so adding extra params to log but downgrading to debug since it's spamming people's logs.