### PR TITLE
fix: Update IRK device source addresses on change

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,14 +20,16 @@
     {
       // Example of attaching to my production server
       "name": "Python: Attach Remote",
-      "type": "python",
+      "type": "debugpy",
       "request": "attach",
-      "port": 5678,
-      "host": "homeassistant.local",
+      "connect": {
+        "port": 5678,
+        "host": "homeassistant.home"
+      },
       "pathMappings": [
         {
           "localRoot": "${workspaceFolder}",
-          "remoteRoot": "/usr/src/homeassistant"
+          "remoteRoot": "/config"
         }
       ]
     }


### PR DESCRIPTION
Fixes IRK (Private BLE Device) devices not updating their source_address, causing the readings to go stale.