### PR TITLE
fix: Create unique Private BLE tracker entity name #144

### DIFF
--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -67,7 +67,7 @@ class BermudaDeviceTracker(BermudaEntity, BaseTrackerEntity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
-    _attr_name = None
+    _attr_name = "Bermuda Tracker"
 
     @property
     def unique_id(self):


### PR DESCRIPTION
- Default entity name caused confusion by being identical to the Private BLE Device-provided entity name. Appened "Bermuda Tracker" to name to create easily-distinguishable tracker name and id. Fixes issue #144 