### PR TITLE
fix (performance): Pruning of device states

### DIFF
--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -73,6 +73,27 @@ BEACON_PRIVATE_BLE_DEVICE: Final = (
     "private_ble_device"  # meta-device create to track private ble device
 )
 
+# Bluetooth Device Address Type - classify MAC addresses
+BDADDR_TYPE_UNKNOWN: Final = "bd_addr_type_unknown"  # uninitialised
+BDADDR_TYPE_OTHER: Final = "bd_addr_other"  # Default 48bit MAC
+BDADDR_TYPE_PRIVATE_RESOLVABLE: Final = "bd_addr_private_resolvable"
+BDADDR_TYPE_NOT_MAC48: Final = "bd_addr_not_mac48"
+
+
+# Device entry pruning. Letting the gathered list of devices grow forever makes the
+# processing loop slower. It doesn't seem to have as much impact on memory, but it
+# would certainly use up more, and gets worse in high "traffic" areas.
+#
+# Pruning ignores tracked devices (ie, ones we keep sensors for) and scanners. It also
+# avoids pruning the most recent IRK for a known private device.
+#
+# IRK devices typically change their MAC every 15 minutes, so 96 addresses/day.
+#
+PRUNE_MAX_COUNT = 1000  # How many device entries to allow at maximum
+PRUNE_TIME_INTERVAL = 310  # Every 5m10s, prune stale devices
+PRUNE_TIME_DEFAULT = 259200  # Max age of regular device entries (3days)
+PRUNE_TIME_IRK = 3600  # Resolvable Private addresses change often, prune regularly (1h)
+
 DOCS = {}
 
 


### PR DESCRIPTION
Keeping "every address ever seen" causes the processing loop to slow down over time. For example, In my low-density urban environment 5 days gathered 6k entries, all bar 30 were resolvable private addresses (about 10 physical devices, 96 addresses each per day). At 6k entries and only a single proxy, loop time for updates went from 5ms to over 100ms. Dump file size goes from 62kB to 14MB. Trimming IRK source addresses in particular is clearly required, but keeping a cap on other advertisements is wise, too.

Also implemented a cap on total device count, currently 1000. Again, this is only in addition to the number of configured devices, so *should* be OK for almost any use-case, and protects against being flooded with MACs.

- Define `address_type` (replaces `mac_is_random`) to track which addresses are IRK versus normal BLE MACs (vs non-MAC addresses like IRK, iBeacon UUID etc)

- Define PRUNE_TIME for IRK sources and for other address types (1 hour, 3 days respectively).
- Prune discovered devices, unless
  - it's the last known source for a beacon or Private BLE Device
  - We have it in our "configured_devices" config

Sites may see reduced CPU time, and possibly a small blip each 5m10s for the pruning.