### PR TITLE
fix: Resolve infinite loop on config reload in 2024.5

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -196,7 +196,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    entry.add_update_listener(async_reload_entry)
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True
 
 


### PR DESCRIPTION
- Only showed up once on 2024.5.x, submitting new config caused infinite loop due to the listener not being un-subscribed when entry was unloaded.
- Hopefully resolves #185 