### PR TITLE
Fix!: race condition in 2024.6.0b6

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -105,11 +105,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
-    try:
-        await async_unload_entry(hass, entry)
-    except ValueError:
-        _LOGGER.warning(
-            "Exception trying to unload entry, but will continue with setup anyway"
-        )
-
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -320,7 +320,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
         dev = self._get_device(address)
         if dev is not None:
             dev.create_sensor_done = True
-            _LOGGER.debug("Sensor confirmed created for %s", address)
+            # _LOGGER.debug("Sensor confirmed created for %s", address)
         else:
             _LOGGER.warning("Very odd, we got sensor_created for non-tracked device")
 
@@ -329,7 +329,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
         dev = self._get_device(address)
         if dev is not None:
             dev.create_tracker_done = True
-            _LOGGER.debug("Device_tracker confirmed created for %s", address)
+            # _LOGGER.debug("Device_tracker confirmed created for %s", address)
         else:
             _LOGGER.warning("Very odd, we got sensor_created for non-tracked device")
 

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -14,7 +14,6 @@ from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import _LOGGER
 from .const import DOMAIN
 from .const import SIGNAL_DEVICE_NEW
 from .coordinator import BermudaDataUpdateCoordinator
@@ -50,9 +49,10 @@ async def async_setup_entry(
             async_add_devices(entities, False)
             created_devices.append(address)
         else:
-            _LOGGER.debug(
-                "Ignoring create request for existing dev_tracker %s", address
-            )
+            # _LOGGER.debug(
+            #     "Ignoring create request for existing dev_tracker %s", address
+            # )
+            pass
         # tell the co-ord we've done it.
         coordinator.device_tracker_created(address)
 

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -59,14 +59,15 @@ async def async_setup_entry(
                 entities.append(
                     BermudaSensorScannerRangeRaw(coordinator, entry, address, scanner)
                 )
-            _LOGGER.debug("Sensor received new_device signal for %s", address)
+            # _LOGGER.debug("Sensor received new_device signal for %s", address)
             # We set update before add to False because we are being
             # call(back(ed)) from the update, so causing it to call another would be... bad.
             async_add_devices(entities, False)
             created_devices.append(address)
         else:
             # We've already created this one.
-            _LOGGER.debug("Ignoring duplicate creation request for %s", address)
+            # _LOGGER.debug("Ignoring duplicate creation request for %s", address)
+            pass
         # tell the co-ord we've done it.
         coordinator.sensor_created(address)
 


### PR DESCRIPTION
- Fix race condition in reload that caused wedge/race in 2024.6.0b6 when a new device was added
- Quieted some debug messages re entity creation