### PR TITLE
feat: Diagnonstics and Redaction support

### DIFF
--- a/custom_components/bermuda/diagnostics.py
+++ b/custom_components/bermuda/diagnostics.py
@@ -1,0 +1,27 @@
+"""Diagnostics support for WLED."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.core import ServiceCall
+
+from .const import DOMAIN
+from .coordinator import BermudaDataUpdateCoordinator
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: BermudaDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    # Param structure for service call
+    call = ServiceCall(DOMAIN, "dump_devices", {"redact": True})
+
+    data: dict[str, Any] = {
+        "devices": await coordinator.service_dump_devices(call),
+    }
+    return data

--- a/custom_components/bermuda/services.yaml
+++ b/custom_components/bermuda/services.yaml
@@ -5,3 +5,11 @@ dump_devices:
       required: false
       example: "EE:E8:37:9F:6B:54 C7:B8:C6:B0:27:11 AA:AA:AA:AA:AA:AA"
       default: ""
+    configured_devices:
+      required: false
+      example: "False"
+      default: true
+    redact:
+      required: false
+      example: "False"
+      default: false

--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -60,6 +60,14 @@
         "addresses": {
           "name": "Addresses",
           "description": "An optional space-separated list of MAC addresses to return info on. If blank get all addresses."
+        },
+        "configured_devices": {
+          "name": "Configured Devices",
+          "description": "Select to include only scanners and configured devices in the output."
+        },
+        "redact": {
+          "name": "Redact",
+          "description": "Set to TRUE to ensure MAC addresses are redacted in output for privacy."
         }
       }
     }


### PR DESCRIPTION
- `dump_devices` service call now supports:
  - `configured_devices` toggle to include explicitly configured devices
  - `redact` toggle to anonymise all addresses by adding still-tracable identifiers.
- New Download Diagnostics support for troubleshooting. Uses the new redacted output from `dump_devices`.