### PR TITLE
feat: Show active device and scanner count in configure

### DIFF
--- a/custom_components/bermuda/diagnostics.py
+++ b/custom_components/bermuda/diagnostics.py
@@ -22,6 +22,8 @@ async def async_get_config_entry_diagnostics(
     call = ServiceCall(DOMAIN, "dump_devices", {"redact": True})
 
     data: dict[str, Any] = {
+        "active_devices": f"{coordinator.count_active_devices()}/{len(coordinator.devices)}",
+        "active_scanners": f"{coordinator.count_active_scanners()}/{len(coordinator.scanner_list)}",
         "devices": await coordinator.service_dump_devices(call),
     }
     return data

--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -19,6 +19,9 @@
   },
   "options": {
     "step": {
+      "init": {
+        "description": "Bermuda can currently see {device_count} bluetooth devices, reported across {scanner_count} bluetooth scanner devices. {status}"
+      },
       "globalopts": {
         "data": {
           "max_area_radius": "Max radius in metres for simple AREA detection",
@@ -39,6 +42,10 @@
           "attenuation": "After setting ref_power at 1 metre, adjust attenuation so that other distances read correctly - more or less.",
           "ref_power": "Put your most-common beacon 1 metre (3.28') away from your most-common proxy / scanner. Adjust ref_power until the distance sensor shows a lowest (not average) distance of 1 metre."
         }
+      },
+      "selectdevices": {
+        "title": "Select Devices",
+        "description": "Choose which devices you wish to track. If no devices appear below, then Bermuda is not seeing any data coming from Bluetooth scanners. Ensure you have an esphome ble_proxy device, Shelly devices with bluetooth proxy configured or a local bluetooth adaptor."
       }
     }
   },


### PR DESCRIPTION
- The configure dialog (options flow) now displays the count of total and recently-active scanners and devices.
- These counts are also include in the diagnostics download.