### PR TITLE
chore: fix versioning in release zip and HACS settings

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,12 @@ jobs:
           version="${{ github.event.release.tag_name }}"
           version="${version,,}"
           version="${version#v}"
-          sed -i '/VERSION.=./c\VERSION = "${version}"' "${{ env.BERMUDA_ROOT_DIR }}/const.py"
-          (jq '.version = "${version}"' "${{ env.BERMUDA_ROOT_DIR }}/manifest.json") > "${{ env.BERMUDA_ROOT_DIR }}/manifest.json.tmp"
+          # update const.py
+          sed -i \
+            "/^VERSION.*=./c\VERSION = \"${version}\"" \
+            "${{ env.BERMUDA_ROOT_DIR }}/const.py"
+          # update manifest.json
+          jq ".version = \"${version}\"" "${{ env.BERMUDA_ROOT_DIR }}/manifest.json" > "${{ env.BERMUDA_ROOT_DIR }}/manifest.json.tmp"
           mv "${{ env.BERMUDA_ROOT_DIR }}/manifest.json.tmp" "${{ env.BERMUDA_ROOT_DIR }}/manifest.json"
 
       - name: Zip the integration directory

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,8 @@
 {
   "name": "Bermuda BLE Trilateration",
   "hacs": "1.6.0",
-  "homeassistant": "2023.8",
-  "render_readme": true
+  "homeassistant": "2024.6",
+  "render_readme": true,
+  "zip_release": true,
+  "filename": "bermuda.zip"
 }


### PR DESCRIPTION
- Fixed quoting issue with auto version updates
- Configure HACS to use zipped release files
- Bumped minimum HA version to 2024.6