### PR TITLE
Update config_flow.py: Fix Syntax Error in config_flow.py: Replace Double Quotes with Single Quotes in f-string

### DIFF
--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -231,7 +231,7 @@ class BermudaOptionsFlowHandler(config_entries.OptionsFlow):
                 options_metadevices.append(
                     {
                         "value": device.address.upper(),
-                        "label": f"iBeacon: {device.address.upper()} {source_mac} {name if device.address.upper() != name.upper() else ""}",
+                        "label": f"iBeacon: {device.address.upper()} {source_mac} {name if device.address.upper() != name.upper() else ''}",
                     }
                 )
                 continue


### PR DESCRIPTION
Fixed a simple syntax error:
Error: f-string: expecting '}' (<unknown>, line 234)

Replace Double Quotes with Single Quotes in f-string:

Before:
```python
                        "label": f"iBeacon: {device.address.upper()} {source_mac} {name if device.address.upper() != name.upper() else ""}",
```

After:
```python
                        "label": f"iBeacon: {device.address.upper()} {source_mac} {name if device.address.upper() != name.upper() else ''}",
```