### PR TITLE
Bump requirements homeassistant to 2024.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.8.2
-homeassistant>=2024.4.0
+homeassistant>=2024.6.0
 pip>=24.1.1,<24.2
 ruff==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.8.2
-homeassistant>=2024.0.0
+homeassistant>=2024.4.0
 pip>=24.1.1,<24.2
 ruff==0.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.8.2
-homeassistant>=2023.8.0
+homeassistant>=2024.0.0
 pip>=24.1.1,<24.2
 ruff==0.5.2


### PR DESCRIPTION
- hacs.json already had minver of 2024.6 for HA.
- Update requirements.txt to match.