### PR TITLE
Change to HA config of ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,28 +6,11 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 24.2.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.1
     hooks:
-      - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
-        require_serial: true
-  - repo: local
-    hooks:
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]
-        require_serial: true
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
+      - id: ruff
+        args:
+          - --fix
+          - --unsafe-fixes
+      - id: ruff-format

--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -7,21 +7,20 @@ https://github.com/agittins/bermuda
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
-from homeassistant.core import HomeAssistant
+from typing import TYPE_CHECKING
+
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 
 # from homeassistant.helpers.device_registry import EventDeviceRegistryUpdatedData
-from homeassistant.helpers.device_registry import DeviceEntry
-from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.device_registry import DeviceEntry, format_mac
 
-from .const import _LOGGER
-from .const import DOMAIN
-from .const import PLATFORMS
-from .const import STARTUP_MESSAGE
+from .const import _LOGGER, DOMAIN, PLATFORMS, STARTUP_MESSAGE
 from .coordinator import BermudaDataUpdateCoordinator
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import Config, HomeAssistant
 
 # from .const import _LOGGER_SPAM_LESS
 
@@ -35,9 +34,7 @@ from .coordinator import BermudaDataUpdateCoordinator
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
-async def async_setup(
-    hass: HomeAssistant, config: Config
-):  # pylint: disable=unused-argument;
+async def async_setup(hass: HomeAssistant, config: Config):  # pylint: disable=unused-argument;
     """Setting up this integration using YAML is not supported."""
     return True
 
@@ -47,9 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if hass.data.get(DOMAIN) is None:
         _LOGGER.info(STARTUP_MESSAGE)
 
-    coordinator = hass.data.setdefault(DOMAIN, {})[entry.entry_id] = (
-        BermudaDataUpdateCoordinator(hass, entry)
-    )
+    coordinator = hass.data.setdefault(DOMAIN, {})[entry.entry_id] = BermudaDataUpdateCoordinator(hass, entry)
 
     await coordinator.async_refresh()
 
@@ -95,9 +90,7 @@ async def async_remove_config_entry_device(
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
-    if unload_result := await hass.config_entries.async_unload_platforms(
-        entry, PLATFORMS
-    ):
+    if unload_result := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         _LOGGER.debug("Unloaded platforms.")
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_result

--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -1,4 +1,5 @@
-"""Bermuda's internal representation of a bluetooth device.
+"""
+Bermuda's internal representation of a bluetooth device.
 
 Each discovered bluetooth device (ie, every found transmitter) will
 have one of these entries created for it. These are not HA 'devices' but
@@ -6,26 +7,22 @@ our own internal thing. They directly correspond to the entries you will
 see when calling the dump_devices service call.
 
 Even devices which are not configured/tracked will get entries created
-for them, so we can use them to contribute towards measurements."""
+for them, so we can use them to contribute towards measurements.
+"""
 
 from __future__ import annotations
 
-from homeassistant.components.bluetooth import MONOTONIC_TIME
-from homeassistant.components.bluetooth import BluetoothScannerDevice
-from homeassistant.const import STATE_HOME
-from homeassistant.const import STATE_NOT_HOME
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.components.bluetooth import MONOTONIC_TIME, BluetoothScannerDevice
+from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.helpers.device_registry import format_mac
 
 from .bermuda_device_scanner import BermudaDeviceScanner
-from .const import BDADDR_TYPE_UNKNOWN
-from .const import CONF_DEVICES
-from .const import CONF_DEVTRACK_TIMEOUT
-from .const import DEFAULT_DEVTRACK_TIMEOUT
+from .const import BDADDR_TYPE_UNKNOWN, CONF_DEVICES, CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT
 
 
 class BermudaDevice(dict):
-    """This class is to represent a single bluetooth "device" tracked by Bermuda.
+    """
+    This class is to represent a single bluetooth "device" tracked by Bermuda.
 
     "device" in this context means a bluetooth receiver like an ESPHome
     running bluetooth_proxy or a bluetooth transmitter such as a beacon,
@@ -35,8 +32,8 @@ class BermudaDevice(dict):
     become entities in homeassistant, since there might be a _lot_ of them.
     """
 
-    def __init__(self, address, options):
-        """Initial (empty) data"""
+    def __init__(self, address, options) -> None:
+        """Initial (empty) data."""
         self.name: str | None = None
         self.local_name: str | None = None
         self.prefname: str | None = None  # "preferred" name - ideally local_name
@@ -54,12 +51,8 @@ class BermudaDevice(dict):
         self.connectable: bool = False
         self.is_scanner: bool = False
         self.beacon_type: set = set()
-        self.beacon_sources = (
-            []
-        )  # list of MAC addresses that have advertised this beacon
-        self.beacon_unique_id: str | None = (
-            None  # combined uuid_major_minor for *really* unique id
-        )
+        self.beacon_sources = []  # list of MAC addresses that have advertised this beacon
+        self.beacon_unique_id: str | None = None  # combined uuid_major_minor for *really* unique id
         self.beacon_uuid: str | None = None
         self.beacon_major: str | None = None
         self.beacon_minor: str | None = None
@@ -69,13 +62,12 @@ class BermudaDevice(dict):
         self.create_sensor: bool = False  # Create/update a sensor for this device
         self.create_sensor_done: bool = False  # Sensor should now exist
         self.create_tracker_done: bool = False  # device_tracker should now exist
-        self.last_seen: float = (
-            0  # stamp from most recent scanner spotting. MONOTONIC_TIME
-        )
+        self.last_seen: float = 0  # stamp from most recent scanner spotting. MONOTONIC_TIME
         self.scanners: dict[str, BermudaDeviceScanner] = {}
 
     def calculate_data(self):
-        """Call after doing update_scanner() calls so that distances
+        """
+        Call after doing update_scanner() calls so that distances
         etc can be freshly smoothed and filtered.
 
         """
@@ -85,9 +77,7 @@ class BermudaDevice(dict):
         # Update whether the device has been seen recently, for device_tracker:
         if (
             self.last_seen is not None
-            and MONOTONIC_TIME()
-            - self.options.get(CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT)
-            < self.last_seen
+            and MONOTONIC_TIME() - self.options.get(CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT) < self.last_seen
         ):
             self.zone = STATE_HOME
         else:
@@ -97,10 +87,9 @@ class BermudaDevice(dict):
             # We are a device we track. Flag for set-up:
             self.create_sensor = True
 
-    def update_scanner(
-        self, scanner_device: BermudaDevice, discoveryinfo: BluetoothScannerDevice
-    ):
-        """Add/Update a scanner entry on this device, indicating a received advertisement
+    def update_scanner(self, scanner_device: BermudaDevice, discoveryinfo: BluetoothScannerDevice):
+        """
+        Add/Update a scanner entry on this device, indicating a received advertisement.
 
         This gets called every time a scanner is deemed to have received an advert for
         this device. It only loads data into the structure, all calculations are done
@@ -128,13 +117,14 @@ class BermudaDevice(dict):
             self.last_seen = device_scanner.stamp
 
     def to_dict(self):
-        """Convert class to serialisable dict for dump_devices"""
+        """Convert class to serialisable dict for dump_devices."""
         out = {}
         for var, val in vars(self).items():
             if var == "scanners":
                 scanout = {}
                 for address, scanner in self.scanners.items():
                     scanout[address] = scanner.to_dict()
-                val = scanout
+                # FIXME: val is overwritten
+                val = scanout  # noqa
             out[var] = val
         return out

--- a/custom_components/bermuda/binary_sensor.py
+++ b/custom_components/bermuda/binary_sensor.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
-from .const import BINARY_SENSOR
-from .const import BINARY_SENSOR_DEVICE_CLASS
-from .const import DEFAULT_NAME
+from .const import BINARY_SENSOR, BINARY_SENSOR_DEVICE_CLASS, DEFAULT_NAME
 from .entity import BermudaEntity
 
 # from .const import DOMAIN

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -62,18 +62,10 @@ LOGSPAM_INTERVAL = 22
 # originators of beacon-like data. We then create a "meta-device" for the beacon's
 # uuid. Other non-static-mac protocols should use this method as well, by adding their
 # own BEACON_ types.
-BEACON_IBEACON_SOURCE: Final = (
-    "beacon source"  # The source-device sending a beacon packet (MAC-tracked)
-)
-BEACON_IBEACON_DEVICE: Final = (
-    "beacon device"  # The meta-device created to track the beacon
-)
-BEACON_PRIVATE_BLE_SOURCE: Final = (
-    "private_ble_src"  # current (random) MAC of a private ble device
-)
-BEACON_PRIVATE_BLE_DEVICE: Final = (
-    "private_ble_device"  # meta-device create to track private ble device
-)
+BEACON_IBEACON_SOURCE: Final = "beacon source"  # The source-device sending a beacon packet (MAC-tracked)
+BEACON_IBEACON_DEVICE: Final = "beacon device"  # The meta-device created to track the beacon
+BEACON_PRIVATE_BLE_SOURCE: Final = "private_ble_src"  # current (random) MAC of a private ble device
+BEACON_PRIVATE_BLE_DEVICE: Final = "private_ble_device"  # meta-device create to track private ble device
 
 # Bluetooth Device Address Type - classify MAC addresses
 BDADDR_TYPE_UNKNOWN: Final = "bd_addr_type_unknown"  # uninitialised
@@ -101,9 +93,7 @@ PRUNE_TIME_IRK = 3600  # Resolvable Private addresses change often, prune regula
 DOCS = {}
 
 
-HIST_KEEP_COUNT = (
-    10  # How many old timestamps, rssi, etc to keep for each device/scanner pairing.
-)
+HIST_KEEP_COUNT = 10  # How many old timestamps, rssi, etc to keep for each device/scanner pairing.
 
 # Config entry DATA entries
 
@@ -121,13 +111,11 @@ DOCS[CONF_MAX_RADIUS] = "For simple area-detection, max radius from receiver"
 CONF_MAX_VELOCITY, DEFAULT_MAX_VELOCITY = "max_velocity", 3
 DOCS[CONF_MAX_VELOCITY] = (
     "In metres per second - ignore readings that imply movement away faster than",
-    "this limit. 3m/s (10km/h) is good."  # fmt: skip
+    "this limit. 3m/s (10km/h) is good.",  # fmt: skip
 )
 
 CONF_DEVTRACK_TIMEOUT, DEFAULT_DEVTRACK_TIMEOUT = "devtracker_nothome_timeout", 30
-DOCS[CONF_DEVTRACK_TIMEOUT] = (
-    "Timeout in seconds for setting devices as `Not Home` / `Away`."  # fmt: skip
-)
+DOCS[CONF_DEVTRACK_TIMEOUT] = "Timeout in seconds for setting devices as `Not Home` / `Away`."  # fmt: skip
 
 CONF_ATTENUATION, DEFAULT_ATTENUATION = "attenuation", 3
 DOCS[CONF_ATTENUATION] = "Factor for environmental signal attenuation."
@@ -137,7 +125,7 @@ DOCS[CONF_REF_POWER] = "Default RSSI for signal at 1 metre."
 CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL = "update_interval", 10
 DOCS[CONF_UPDATE_INTERVAL] = (
     "Maximum time between sensor updates in seconds. Smaller intervals",
-    "means more data, bigger database."  # fmt: skip
+    "means more data, bigger database.",  # fmt: skip
 )
 
 CONF_SMOOTHING_SAMPLES, DEFAULT_SMOOTHING_SAMPLES = "smoothing_samples", 20

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -1,23 +1,25 @@
-"""Create device_tracker entities for Bermuda devices"""
+"""Create device_tracker entities for Bermuda devices."""
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.device_tracker.config_entry import BaseTrackerEntity
 from homeassistant.components.device_tracker.const import SourceType
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_HOME
-from homeassistant.core import HomeAssistant
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
-from .const import SIGNAL_DEVICE_NEW
-from .coordinator import BermudaDataUpdateCoordinator
+from .const import DOMAIN, SIGNAL_DEVICE_NEW
 from .entity import BermudaEntity
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import BermudaDataUpdateCoordinator
 
 
 async def async_setup_entry(
@@ -31,10 +33,9 @@ async def async_setup_entry(
     created_devices = []  # list of devices we've already created entities for
 
     @callback
-    def device_new(
-        address: str, scanners: list[str]
-    ) -> None:  # pylint: disable=unused-argument
-        """Create entities for newly-found device
+    def device_new(address: str, scanners: list[str]) -> None:  # pylint: disable=unused-argument
+        """
+        Create entities for newly-found device.
 
         Called from the data co-ordinator when it finds a new device that needs
         to have sensors created. Not called directly, but via the dispatch
@@ -72,8 +73,10 @@ class BermudaDeviceTracker(BermudaEntity, BaseTrackerEntity):
 
     @property
     def unique_id(self):
-        """ "Uniquely identify this sensor so that it gets stored in the entity_registry,
-        and can be maintained / renamed etc by the user"""
+        """
+        "Uniquely identify this sensor so that it gets stored in the entity_registry,
+        and can be maintained / renamed etc by the user.
+        """
         return self._device.unique_id
 
     @property
@@ -94,8 +97,4 @@ class BermudaDeviceTracker(BermudaEntity, BaseTrackerEntity):
     @property
     def icon(self) -> str:
         """Return device icon."""
-        return (
-            "mdi:bluetooth-connect"
-            if self._device.zone == STATE_HOME
-            else "mdi:bluetooth-off"
-        )
+        return "mdi:bluetooth-connect" if self._device.zone == STATE_HOME else "mdi:bluetooth-off"

--- a/custom_components/bermuda/diagnostics.py
+++ b/custom_components/bermuda/diagnostics.py
@@ -2,20 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.bluetooth.api import _get_manager
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.core import ServiceCall
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import DOMAIN
-from .coordinator import BermudaDataUpdateCoordinator
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+
+    from .coordinator import BermudaDataUpdateCoordinator
 
 
-async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
-) -> dict[str, Any]:
+async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     coordinator: BermudaDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 

--- a/custom_components/bermuda/log_spam_less.py
+++ b/custom_components/bermuda/log_spam_less.py
@@ -1,32 +1,39 @@
-"""Custom logging class for Bermuda"""
+"""Custom logging class for Bermuda."""
 
 from __future__ import annotations
 
-import logging
+from typing import TYPE_CHECKING
 
 from homeassistant.components.bluetooth import MONOTONIC_TIME
 
+if TYPE_CHECKING:
+    import logging
+
 
 class BermudaLogSpamLess:
-    """A class to provide a way to cache specific log entries so we can rate-limit them.
+    """
+    A class to provide a way to cache specific log entries so we can rate-limit them.
 
     Log via this class, adding a "key" to each call, and we will rate-limit any later log
-    messages that use the same key by the spam_interval defined in the constructor."""
+    messages that use the same key by the spam_interval defined in the constructor.
+    """
 
     _logger: logging.Logger
     _interval: float
     _keycache = {}
 
-    def __init__(self, logger: logging.Logger, spam_interval: float):
+    def __init__(self, logger: logging.Logger, spam_interval: float) -> None:
         self._logger = logger
         self._interval = spam_interval
 
     def _check_key(self, key):
-        """Check if the given key has been used recently.
+        """
+        Check if the given key has been used recently.
 
         Returns -1 if the message should be suppressed,
         but if the message should be logged it returns the number of attempted uses
-        since last time it was sent - which might be zero."""
+        since last time it was sent - which might be zero.
+        """
         if key in self._keycache:
             # key exists, check timestamps
             cache = self._keycache[key]
@@ -48,8 +55,10 @@ class BermudaLogSpamLess:
             return 0
 
     def _prep_message(self, key, msg):
-        """Checks if message should be logged and returns the message reformatted
-        to indicate how many previous messages were supressed."""
+        """
+        Checks if message should be logged and returns the message reformatted
+        to indicate how many previous messages were supressed.
+        """
         count = self._check_key(key)
         if count == 0:
             # No previously suppressed, just log it as-is.
@@ -59,25 +68,25 @@ class BermudaLogSpamLess:
         return None
 
     def debug(self, key, msg, *args, **kwargs):
-        """Send log message, if no log was issued with the same key recently"""
+        """Send log message, if no log was issued with the same key recently."""
         newmsg = self._prep_message(key, msg)
         if newmsg is not None:
             self._logger.debug(newmsg, *args, **kwargs)
 
     def info(self, key, msg, *args, **kwargs):
-        """Send log message, if no log was issued with the same key recently"""
+        """Send log message, if no log was issued with the same key recently."""
         newmsg = self._prep_message(key, msg)
         if newmsg is not None:
             self._logger.info(newmsg, *args, **kwargs)
 
     def warning(self, key, msg, *args, **kwargs):
-        """Send log message, if no log was issued with the same key recently"""
+        """Send log message, if no log was issued with the same key recently."""
         newmsg = self._prep_message(key, msg)
         if newmsg is not None:
             self._logger.warning(newmsg, *args, **kwargs)
 
     def error(self, key, msg, *args, **kwargs):
-        """Send log message, if no log was issued with the same key recently"""
+        """Send log message, if no log was issued with the same key recently."""
         newmsg = self._prep_message(key, msg)
         if newmsg is not None:
             self._logger.error(newmsg, *args, **kwargs)

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -2,28 +2,24 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from homeassistant import config_entries
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.components.sensor.const import SensorDeviceClass
-from homeassistant.components.sensor.const import SensorStateClass
-from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT
-from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.const import UnitOfLength
-from homeassistant.core import HomeAssistant
-from homeassistant.core import callback
+from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, STATE_UNAVAILABLE, UnitOfLength
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import _LOGGER
-from .const import ADDR_TYPE_IBEACON
-from .const import ADDR_TYPE_PRIVATE_BLE_DEVICE
-from .const import DOMAIN
-from .const import SIGNAL_DEVICE_NEW
-from .coordinator import BermudaDataUpdateCoordinator
+from .const import _LOGGER, ADDR_TYPE_IBEACON, ADDR_TYPE_PRIVATE_BLE_DEVICE, DOMAIN, SIGNAL_DEVICE_NEW
 from .entity import BermudaEntity
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from homeassistant import config_entries
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+    from .coordinator import BermudaDataUpdateCoordinator
 
 
 async def async_setup_entry(
@@ -38,7 +34,8 @@ async def async_setup_entry(
 
     @callback
     def device_new(address: str, scanners: list[str]) -> None:
-        """Create entities for newly-found device
+        """
+        Create entities for newly-found device.
 
         Called from the data co-ordinator when it finds a new device that needs
         to have sensors created. Not called directly, but via the dispatch
@@ -53,12 +50,8 @@ async def async_setup_entry(
             entities.append(BermudaSensorRssi(coordinator, entry, address))
 
             for scanner in scanners:
-                entities.append(
-                    BermudaSensorScannerRange(coordinator, entry, address, scanner)
-                )
-                entities.append(
-                    BermudaSensorScannerRangeRaw(coordinator, entry, address, scanner)
-                )
+                entities.append(BermudaSensorScannerRange(coordinator, entry, address, scanner))
+                entities.append(BermudaSensorScannerRangeRaw(coordinator, entry, address, scanner))
             # _LOGGER.debug("Sensor received new_device signal for %s", address)
             # We set update before add to False because we are being
             # call(back(ed)) from the update, so causing it to call another would be... bad.
@@ -86,14 +79,18 @@ class BermudaSensor(BermudaEntity, SensorEntity):
 
     @property
     def unique_id(self):
-        """ "Uniquely identify this sensor so that it gets stored in the entity_registry,
-        and can be maintained / renamed etc by the user"""
+        """
+        "Uniquely identify this sensor so that it gets stored in the entity_registry,
+        and can be maintained / renamed etc by the user.
+        """
         return self._device.unique_id
 
     @property
     def has_entity_name(self) -> bool:
-        """Indicate that our name() method only returns the entity's name,
-        so that HA should prepend the device name for the user."""
+        """
+        Indicate that our name() method only returns the entity's name,
+        so that HA should prepend the device name for the user.
+        """
         return True
 
     @property
@@ -109,11 +106,8 @@ class BermudaSensor(BermudaEntity, SensorEntity):
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        """Declare if entity should be automatically enabled on adding"""
-        if self.name in ["Area", "Distance"]:
-            return True
-        else:
-            return False
+        """Declare if entity should be automatically enabled on adding."""
+        return self.name in ["Area", "Distance"]
 
     @property
     def device_class(self):
@@ -148,7 +142,7 @@ class BermudaSensor(BermudaEntity, SensorEntity):
 
 
 class BermudaSensorScanner(BermudaSensor):
-    """Sensor for name of nearest detected scanner"""
+    """Sensor for name of nearest detected scanner."""
 
     @property
     def unique_id(self):
@@ -164,11 +158,11 @@ class BermudaSensorScanner(BermudaSensor):
 
 
 class BermudaSensorRssi(BermudaSensor):
-    """Sensor for RSSI of closest scanner"""
+    """Sensor for RSSI of closest scanner."""
 
     @property
     def unique_id(self):
-        """Return unique id for the entity"""
+        """Return unique id for the entity."""
         return f"{self._device.unique_id}_rssi"
 
     @property
@@ -177,9 +171,7 @@ class BermudaSensorRssi(BermudaSensor):
 
     @property
     def native_value(self):
-        return self._cached_ratelimit(
-            self._device.area_rssi, fast_falling=False, fast_rising=True
-        )
+        return self._cached_ratelimit(self._device.area_rssi, fast_falling=False, fast_rising=True)
 
     @property
     def device_class(self):
@@ -191,17 +183,19 @@ class BermudaSensorRssi(BermudaSensor):
 
     @property
     def state_class(self):
-        """These are graphable measurements"""
+        """These are graphable measurements."""
         return SensorStateClass.MEASUREMENT
 
 
 class BermudaSensorRange(BermudaSensor):
-    """Extra sensor for range-to-closest-area"""
+    """Extra sensor for range-to-closest-area."""
 
     @property
     def unique_id(self):
-        """ "Uniquely identify this sensor so that it gets stored in the entity_registry,
-        and can be maintained / renamed etc by the user"""
+        """
+        "Uniquely identify this sensor so that it gets stored in the entity_registry,
+        and can be maintained / renamed etc by the user.
+        """
         return f"{self._device.unique_id}_range"
 
     @property
@@ -210,7 +204,7 @@ class BermudaSensorRange(BermudaSensor):
 
     @property
     def native_value(self):
-        """Return the native value of the sensor"""
+        """Return the native value of the sensor."""
         distance = self._device.area_distance
         if distance is not None:
             return self._cached_ratelimit(round(distance, 1))
@@ -222,12 +216,12 @@ class BermudaSensorRange(BermudaSensor):
 
     @property
     def native_unit_of_measurement(self):
-        """Results are in metres"""
+        """Results are in metres."""
         return UnitOfLength.METERS
 
     @property
     def state_class(self):
-        """Measurement should result in graphed results"""
+        """Measurement should result in graphed results."""
         return SensorStateClass.MEASUREMENT
 
 
@@ -240,7 +234,7 @@ class BermudaSensorScannerRange(BermudaSensorRange):
         config_entry,
         address: str,
         scanner_address: str,
-    ):
+    ) -> None:
         super().__init__(coordinator, config_entry, address)
         self.coordinator = coordinator
         self.config_entry = config_entry
@@ -257,9 +251,11 @@ class BermudaSensorScannerRange(BermudaSensorRange):
 
     @property
     def native_value(self):
-        """Expose distance to given scanner.
+        """
+        Expose distance to given scanner.
 
-        Don't break if that scanner's never heard of us!"""
+        Don't break if that scanner's never heard of us!
+        """
         devscanner = self._device.scanners.get(self._scanner.address, {})
         distance = getattr(devscanner, "rssi_distance", None)
         if distance is not None:
@@ -282,7 +278,7 @@ class BermudaSensorScannerRange(BermudaSensorRange):
 
 
 class BermudaSensorScannerRangeRaw(BermudaSensorScannerRange):
-    """Provides un-filtered latest distances per-scanner"""
+    """Provides un-filtered latest distances per-scanner."""
 
     @property
     def unique_id(self):
@@ -294,9 +290,11 @@ class BermudaSensorScannerRangeRaw(BermudaSensorScannerRange):
 
     @property
     def native_value(self):
-        """Expose distance to given scanner.
+        """
+        Expose distance to given scanner.
 
-        Don't break if that scanner's never heard of us!"""
+        Don't break if that scanner's never heard of us!
+        """
         devscanner = self._device.scanners.get(self._scanner.address, {})
         distance = getattr(devscanner, "rssi_distance_raw", None)
         if distance is not None:

--- a/custom_components/bermuda/switch.py
+++ b/custom_components/bermuda/switch.py
@@ -4,9 +4,7 @@ from __future__ import annotations
 
 from homeassistant.components.switch import SwitchEntity
 
-from .const import DEFAULT_NAME
-from .const import ICON
-from .const import SWITCH
+from .const import DEFAULT_NAME, ICON, SWITCH
 from .entity import BermudaEntity
 
 # from .const import DOMAIN

--- a/custom_components/bermuda/util.py
+++ b/custom_components/bermuda/util.py
@@ -1,10 +1,11 @@
-"""General helper utilities for Bermuda"""
+"""General helper utilities for Bermuda."""
 
 from __future__ import annotations
 
 
 def rssi_to_metres(rssi, ref_power=None, attenuation=None):
-    """Convert instant rssi value to a distance in metres
+    """
+    Convert instant rssi value to a distance in metres.
 
     Based on the information from
     https://mdpi-res.com/d_attachment/applsci/applsci-10-02003/article_deploy/applsci-10-02003.pdf?version=1584265508
@@ -27,12 +28,12 @@ def rssi_to_metres(rssi, ref_power=None, attenuation=None):
         return False
         # attenuation= self.attenuation
 
-    distance = 10 ** ((ref_power - rssi) / (10 * attenuation))
-    return distance
+    return 10 ** ((ref_power - rssi) / (10 * attenuation))
 
 
 def clean_charbuf(instring: str | None) -> str:
-    """Some people writing C on bluetooth devices seem to
+    """
+    Some people writing C on bluetooth devices seem to
     get confused between char arrays, strings and such. This
     function takes a potentially dodgy charbuf from a bluetooth
     device and cleans it of leading/trailing cruft

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,121 @@
+# Adapted from https://github.com/ludeeus/integration_blueprint/blob/main/.ruff.toml
+[tool.ruff]
+target-version = "py312"
+line-length=120 # This is all me and not HA - I will die on the hill that 80 is too short
+
+[tool.ruff.lint]
+select = [
+    "ALL",
+]
+
+ignore = [
+    "ANN101", # Missing type annotation for `self` in method
+    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
+    "D203", # no-blank-line-before-class (incompatible with formatter)
+    "D212", # multi-line-summary-first-line (incompatible with formatter)
+    "COM812", # incompatible with formatter
+    "ISC001", # incompatible with formatter
+    "ERA001", # commented out code
+    "D401", # First line should be in imperative - let's skip for now
+    "D205", # 1 blank line required between summary line and description
+    "ANN001", # Return type annoations - should be done later as lot of manual changes
+    "ANN003", # Type annotation for **kwargs
+    "PGH004", # Use specific rule codes for noqa
+    "D102", # Docstring in public method - should be done later
+    "D107", # Dosctring in init
+    "ANN002", # Missing type annotations for *args
+    "ANN202", #Missing return type annotation for private function
+    "RUF012", #Mutable class attributes should be annotated with `typing.ClassVar`
+    "ANN201", #Missing return type annotation for public function should be done later
+    "FBT002", #Boolean default positional argument in function definition
+    "FBT003", # Boolean positional value in function call
+    "ARG001", # Unused function argument
+    "RET505", # Unnecessary elif
+    "PLR2004", # Magic value
+    "PLR0912", # Too many branches
+    "FIX001", # Line contains fixme
+    "TD003", # Missing issue link on the line following this TODO
+    "TD002", # Missing author in TODO
+    "TD001", # Invalid TODO tag in FIXME
+    "SIM108", #Use ternary operator
+    "PLR0915", # Too many statements
+    "FIX002", # Resolve TODO
+    "SIM102", # Use a single if instead of nested if
+    "ANN205", # missing return type annotation for staticmethod
+    "ARG002", # Unused method argument
+    "PGH003", # Use specific rule codes when ignore type issues
+    "D404", # First word of the dosctring should not be "This"
+]
+
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = false
+
+[tool.ruff.lint.pyupgrade]
+keep-runtime-typing = true
+
+[tool.ruff.lint.mccabe]
+max-complexity = 25
+
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/**/*.py" = [
+    "S101", # asserts allowed in tests...
+    "ARG", # Unused function args -> fixtures nevertheless are functionally relevant...
+    "FBT", # Don't care about booleans as positional arguments in tests, e.g. via @pytest.mark.parametrize()
+    "PT004", # Add leading underscore to pytest fixture
+    "ALL" # To keep things easy let's just skip all for now - can be changed later :)
+]
+
+# Grabbed from HA core 2024.7
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+voluptuous = "vol"
+"homeassistant.components.air_quality.PLATFORM_SCHEMA" = "AIR_QUALITY_PLATFORM_SCHEMA"
+"homeassistant.components.alarm_control_panel.PLATFORM_SCHEMA" = "ALARM_CONTROL_PANEL_PLATFORM_SCHEMA"
+"homeassistant.components.binary_sensor.PLATFORM_SCHEMA" = "BINARY_SENSOR_PLATFORM_SCHEMA"
+"homeassistant.components.button.PLATFORM_SCHEMA" = "BUTTON_PLATFORM_SCHEMA"
+"homeassistant.components.calendar.PLATFORM_SCHEMA" = "CALENDAR_PLATFORM_SCHEMA"
+"homeassistant.components.camera.PLATFORM_SCHEMA" = "CAMERA_PLATFORM_SCHEMA"
+"homeassistant.components.climate.PLATFORM_SCHEMA" = "CLIMATE_PLATFORM_SCHEMA"
+"homeassistant.components.conversation.PLATFORM_SCHEMA" = "CONVERSATION_PLATFORM_SCHEMA"
+"homeassistant.components.cover.PLATFORM_SCHEMA" = "COVER_PLATFORM_SCHEMA"
+"homeassistant.components.date.PLATFORM_SCHEMA" = "DATE_PLATFORM_SCHEMA"
+"homeassistant.components.datetime.PLATFORM_SCHEMA" = "DATETIME_PLATFORM_SCHEMA"
+"homeassistant.components.device_tracker.PLATFORM_SCHEMA" = "DEVICE_TRACKER_PLATFORM_SCHEMA"
+"homeassistant.components.event.PLATFORM_SCHEMA" = "EVENT_PLATFORM_SCHEMA"
+"homeassistant.components.fan.PLATFORM_SCHEMA" = "FAN_PLATFORM_SCHEMA"
+"homeassistant.components.geo_location.PLATFORM_SCHEMA" = "GEO_LOCATION_PLATFORM_SCHEMA"
+"homeassistant.components.humidifier.PLATFORM_SCHEMA" = "HUMIDIFIER_PLATFORM_SCHEMA"
+"homeassistant.components.image.PLATFORM_SCHEMA" = "IMAGE_PLATFORM_SCHEMA"
+"homeassistant.components.image_processing.PLATFORM_SCHEMA" = "IMAGE_PROCESSING_PLATFORM_SCHEMA"
+"homeassistant.components.lawn_mower.PLATFORM_SCHEMA" = "LAWN_MOWER_PLATFORM_SCHEMA"
+"homeassistant.components.light.PLATFORM_SCHEMA" = "LIGHT_PLATFORM_SCHEMA"
+"homeassistant.components.lock.PLATFORM_SCHEMA" = "LOCK_PLATFORM_SCHEMA"
+"homeassistant.components.mailbox.PLATFORM_SCHEMA" = "MAILBOX_PLATFORM_SCHEMA"
+"homeassistant.components.media_player.PLATFORM_SCHEMA" = "MEDIA_PLAYER_PLATFORM_SCHEMA"
+"homeassistant.components.notify.PLATFORM_SCHEMA" = "NOTIFY_PLATFORM_SCHEMA"
+"homeassistant.components.number.PLATFORM_SCHEMA" = "NUMBER_PLATFORM_SCHEMA"
+"homeassistant.components.remote.PLATFORM_SCHEMA" = "REMOTE_PLATFORM_SCHEMA"
+"homeassistant.components.scene.PLATFORM_SCHEMA" = "SCENE_PLATFORM_SCHEMA"
+"homeassistant.components.select.PLATFORM_SCHEMA" = "SELECT_PLATFORM_SCHEMA"
+"homeassistant.components.sensor.PLATFORM_SCHEMA" = "SENSOR_PLATFORM_SCHEMA"
+"homeassistant.components.siren.PLATFORM_SCHEMA" = "SIREN_PLATFORM_SCHEMA"
+"homeassistant.components.stt.PLATFORM_SCHEMA" = "STT_PLATFORM_SCHEMA"
+"homeassistant.components.switch.PLATFORM_SCHEMA" = "SWITCH_PLATFORM_SCHEMA"
+"homeassistant.components.text.PLATFORM_SCHEMA" = "TEXT_PLATFORM_SCHEMA"
+"homeassistant.components.time.PLATFORM_SCHEMA" = "TIME_PLATFORM_SCHEMA"
+"homeassistant.components.todo.PLATFORM_SCHEMA" = "TODO_PLATFORM_SCHEMA"
+"homeassistant.components.tts.PLATFORM_SCHEMA" = "TTS_PLATFORM_SCHEMA"
+"homeassistant.components.vacuum.PLATFORM_SCHEMA" = "VACUUM_PLATFORM_SCHEMA"
+"homeassistant.components.valve.PLATFORM_SCHEMA" = "VALVE_PLATFORM_SCHEMA"
+"homeassistant.components.update.PLATFORM_SCHEMA" = "UPDATE_PLATFORM_SCHEMA"
+"homeassistant.components.wake_word.PLATFORM_SCHEMA" = "WAKE_WORD_PLATFORM_SCHEMA"
+"homeassistant.components.water_heater.PLATFORM_SCHEMA" = "WATER_HEATER_PLATFORM_SCHEMA"
+"homeassistant.components.weather.PLATFORM_SCHEMA" = "WEATHER_PLATFORM_SCHEMA"
+"homeassistant.helpers.area_registry" = "ar"
+"homeassistant.helpers.category_registry" = "cr"
+"homeassistant.helpers.config_validation" = "cv"
+"homeassistant.helpers.device_registry" = "dr"
+"homeassistant.helpers.entity_registry" = "er"
+"homeassistant.helpers.floor_registry" = "fr"
+"homeassistant.helpers.issue_registry" = "ir"
+"homeassistant.helpers.label_registry" = "lr"
+"homeassistant.util.dt" = "dt_util"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.8.2
 homeassistant>=2024.6.0
 pip>=24.1.1,<24.2
-ruff==0.5.2
+ruff==0.5.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,9 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 @pytest.fixture(name="skip_notifications", autouse=True)
 def skip_notifications_fixture():
     """Skip notification calls."""
-    with patch("homeassistant.components.persistent_notification.async_create"), patch(
-        "homeassistant.components.persistent_notification.async_dismiss"
+    with (
+        patch("homeassistant.components.persistent_notification.async_create"),
+        patch("homeassistant.components.persistent_notification.async_dismiss"),
     ):
         yield
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -26,12 +26,15 @@ from .const import MOCK_OPTIONS_GLOBALS
 @pytest.fixture(autouse=True)
 def bypass_setup_fixture():
     """Prevent setup."""
-    with patch(
-        "custom_components.bermuda.async_setup",
-        return_value=True,
-    ), patch(
-        "custom_components.bermuda.async_setup_entry",
-        return_value=True,
+    with (
+        patch(
+            "custom_components.bermuda.async_setup",
+            return_value=True,
+        ),
+        patch(
+            "custom_components.bermuda.async_setup_entry",
+            return_value=True,
+        ),
     ):
         yield
 
@@ -42,9 +45,7 @@ def bypass_setup_fixture():
 async def test_successful_config_flow(hass, bypass_get_data):
     """Test a successful config flow."""
     # Initialize a config flow
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
 
     # Check that the config flow shows the user form as the first step
     assert result["type"] == FlowResultType.FORM
@@ -52,9 +53,7 @@ async def test_successful_config_flow(hass, bypass_get_data):
 
     # If a user were to enter `test_username` for username and `test_password`
     # for password, it would result in this function call
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_CONFIG
-    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_CONFIG)
 
     # Check that the config flow is complete and a new entry is created with
     # the input data
@@ -72,16 +71,12 @@ async def test_successful_config_flow(hass, bypass_get_data):
 async def test_failed_config_flow(hass, error_on_get_data):
     """Test a failed config flow due to credential validation failure."""
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "user"
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=MOCK_CONFIG
-    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], user_input=MOCK_CONFIG)
 
     assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
     assert result.get("errors") is None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -33,16 +33,12 @@ async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
     # call, no code from custom_components/bermuda/api.py actually runs.
     assert await async_setup_entry(hass, config_entry)
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(
-        hass.data[DOMAIN][config_entry.entry_id], BermudaDataUpdateCoordinator
-    )
+    assert isinstance(hass.data[DOMAIN][config_entry.entry_id], BermudaDataUpdateCoordinator)
 
     # Reload the entry and assert that the data from above is still there
     assert await async_reload_entry(hass, config_entry) is None
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(
-        hass.data[DOMAIN][config_entry.entry_id], BermudaDataUpdateCoordinator
-    )
+    assert isinstance(hass.data[DOMAIN][config_entry.entry_id], BermudaDataUpdateCoordinator)
 
     # Unload the entry and verify that the data has been removed
     assert await async_unload_entry(hass, config_entry)


### PR DESCRIPTION
Switches to use the ruff linter with configs based off of:

https://github.com/home-assistant/core/blob/dev/pyproject.toml

and

https://github.com/ludeeus/integration_blueprint

Disable a lot of things that wouldn't auto fix just to limit how many changes i was making.

This makes it match a bit more with what HA code looks like so that in the future migrating to Core wouldn't be as much of a challenge.

All changes but ~5 are automatic, disabled anything that would require significant changes. 