### PR TITLE
Fix tests and change some objects

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -8,7 +8,6 @@ https://github.com/agittins/bermuda
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
@@ -35,11 +34,11 @@ from .coordinator import BermudaDataUpdateCoordinator
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
-async def async_setup(
-    hass: HomeAssistant, config: Config
-):  # pylint: disable=unused-argument;
-    """Setting up this integration using YAML is not supported."""
-    return True
+# async def async_setup(
+#     hass: HomeAssistant, config: Config
+# ):  # pylint: disable=unused-argument;
+#     """Setting up this integration using YAML is not supported."""
+#     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -7,10 +7,10 @@ https://github.com/agittins/bermuda
 
 from __future__ import annotations
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 from typing import TYPE_CHECKING
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 
@@ -22,7 +22,7 @@ from .coordinator import BermudaDataUpdateCoordinator
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
-    from homeassistant.core import Config, HomeAssistant
+    from homeassistant.core import HomeAssistant
 
 # from .const import _LOGGER_SPAM_LESS
 

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries
 from homeassistant.components.bluetooth import MONOTONIC_TIME
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import OptionsFlowWithConfigEntry
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.selector import selector
@@ -105,14 +106,12 @@ class BermudaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     #     )
 
 
-class BermudaOptionsFlowHandler(config_entries.OptionsFlow):
+class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
     """Config flow options handler for bermuda."""
 
     def __init__(self, config_entry: ConfigEntry):
         """Initialize HACS options flow."""
-        super().__init__()
-        self.config_entry = config_entry
-        self.options = dict(config_entry.options)
+        super().__init__(config_entry)
         self.coordinator: BermudaDataUpdateCoordinator
         self.devices: dict[str, BermudaDevice]
 

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -6,9 +6,8 @@ from typing import TYPE_CHECKING
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.config_entries import OptionsFlowWithConfigEntry
 from homeassistant.components.bluetooth import MONOTONIC_TIME, BluetoothServiceInfoBleak
+from homeassistant.config_entries import ConfigEntry, OptionsFlowWithConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.selector import selector
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,9 +87,7 @@ def error_get_data_fixture():
 @pytest.fixture()
 async def mock_bermuda_entry(hass: HomeAssistant):
     """This creates a mock config entry"""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", title=NAME
-    )
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", title=NAME)
     config_entry.add_to_hass(hass)
     await hass.async_block_till_done()
     return config_entry
@@ -98,9 +96,7 @@ async def mock_bermuda_entry(hass: HomeAssistant):
 @pytest.fixture()
 async def setup_bermuda_entry(hass: HomeAssistant):
     """This setups a entry so that it can be used."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", title=NAME
-    )
+    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", title=NAME)
     config_entry.add_to_hass(hass)
     await async_setup_component(hass, DOMAIN, {})
     assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bermuda.const import DOMAIN
+from custom_components.bermuda.const import NAME
+
+# from .const import MOCK_OPTIONS
+from .const import MOCK_CONFIG
 
 # from custom_components.bermuda import BermudaDataUpdateCoordinator
 
@@ -72,3 +81,26 @@ def error_get_data_fixture():
 #     """Simulate a discovered advertisement for config_flow"""
 #     with patch("custom_components.bermuda.bluetooth.async_discovered_service_info"):
 #         return SERVICE_INFOS
+
+
+@pytest.fixture()
+async def mock_bermuda_entry(hass: HomeAssistant):
+    """This creates a mock config entry"""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", title=NAME
+    )
+    config_entry.add_to_hass(hass)
+    await hass.async_block_till_done()
+    return config_entry
+
+
+@pytest.fixture()
+async def setup_bermuda_entry(hass: HomeAssistant):
+    """This setups a entry so that it can be used."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", title=NAME
+    )
+    config_entry.add_to_hass(hass)
+    await async_setup_component(hass, DOMAIN, {})
+    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
+    return config_entry

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -17,10 +17,6 @@ from custom_components.bermuda.const import NAME
 from .const import MOCK_CONFIG
 from .const import MOCK_OPTIONS_GLOBALS
 
-# This fixture bypasses the actual setup of the integration
-# since we only want to test the config flow. We test the
-# actual functionality of the integration in other test modules.
-
 
 # Here we simiulate a successful config flow from the backend.
 # Note that we use the `bypass_get_data` fixture here because

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
+from homeassistant.core import HomeAssistant
+
 # from homeassistant.exceptions import ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.bermuda import async_reload_entry
-from custom_components.bermuda import async_setup_entry
-from custom_components.bermuda import async_unload_entry
 from custom_components.bermuda.const import DOMAIN
 from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
 
@@ -21,32 +20,24 @@ from .const import MOCK_CONFIG
 # Home Assistant using the pytest_homeassistant_custom_component plugin.
 # Assertions allow you to verify that the return value of whatever is on the left
 # side of the assertion matches with the right side.
-async def test_setup_unload_and_reload_entry(hass, bypass_get_data):
+async def test_setup_unload_and_reload_entry(
+    hass: HomeAssistant, bypass_get_data, setup_bermuda_entry: MockConfigEntry
+):
     """Test entry setup and unload."""
-    # Create a mock entry so we don't have to go through config flow
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
-
-    # Set up the entry and assert that the values
-    # set during setup are where we expect
-    # them to be. Because we have patched
-    # the BermudaDataUpdateCoordinator.async_get_data
-    # call, no code from custom_components/bermuda/api.py actually runs.
-    assert await async_setup_entry(hass, config_entry)
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
     assert isinstance(
-        hass.data[DOMAIN][config_entry.entry_id], BermudaDataUpdateCoordinator
+        hass.data[DOMAIN][setup_bermuda_entry.entry_id], BermudaDataUpdateCoordinator
     )
 
     # Reload the entry and assert that the data from above is still there
-    assert await async_reload_entry(hass, config_entry) is None
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
+    assert await hass.config_entries.async_reload(setup_bermuda_entry.entry_id)
+    assert DOMAIN in hass.data and setup_bermuda_entry.entry_id in hass.data[DOMAIN]
     assert isinstance(
-        hass.data[DOMAIN][config_entry.entry_id], BermudaDataUpdateCoordinator
+        hass.data[DOMAIN][setup_bermuda_entry.entry_id], BermudaDataUpdateCoordinator
     )
 
     # Unload the entry and verify that the data has been removed
-    assert await async_unload_entry(hass, config_entry)
-    assert config_entry.entry_id not in hass.data[DOMAIN]
+    assert await hass.config_entries.async_unload(setup_bermuda_entry.entry_id)
+    assert setup_bermuda_entry.entry_id not in hass.data[DOMAIN]
 
 
 async def test_setup_entry_exception(hass, error_on_get_data):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,22 +24,12 @@ async def test_setup_unload_and_reload_entry(
     hass: HomeAssistant, bypass_get_data, setup_bermuda_entry: MockConfigEntry
 ):
     """Test entry setup and unload."""
-    # Create a mock entry so we don't have to go through config flow
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
-
-    # Set up the entry and assert that the values
-    # set during setup are where we expect
-    # them to be. Because we have patched
-    # the BermudaDataUpdateCoordinator.async_get_data
-    # call, no code from custom_components/bermuda/api.py actually runs.
-    assert await async_setup_entry(hass, config_entry)
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(hass.data[DOMAIN][config_entry.entry_id], BermudaDataUpdateCoordinator)
+    assert isinstance(hass.data[DOMAIN][setup_bermuda_entry.entry_id], BermudaDataUpdateCoordinator)
 
     # Reload the entry and assert that the data from above is still there
-    assert await async_reload_entry(hass, config_entry) is None
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(hass.data[DOMAIN][config_entry.entry_id], BermudaDataUpdateCoordinator)
+    assert await hass.config_entries.async_reload(setup_bermuda_entry.entry_id)
+    assert DOMAIN in hass.data and setup_bermuda_entry.entry_id in hass.data[DOMAIN]
+    assert isinstance(hass.data[DOMAIN][setup_bermuda_entry.entry_id], BermudaDataUpdateCoordinator)
 
     # Unload the entry and verify that the data has been removed
     assert await hass.config_entries.async_unload(setup_bermuda_entry.entry_id)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,14 +5,10 @@ from __future__ import annotations
 # from homeassistant.components.switch import SERVICE_TURN_OFF
 # from homeassistant.components.switch import SERVICE_TURN_ON
 # from homeassistant.const import ATTR_ENTITY_ID
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.bermuda import async_setup_entry
 
 # from custom_components.bermuda.const import DEFAULT_NAME
-from custom_components.bermuda.const import DOMAIN
 
-from .const import MOCK_CONFIG
 
 # from unittest.mock import call
 # from unittest.mock import patch
@@ -20,37 +16,37 @@ from .const import MOCK_CONFIG
 
 # from custom_components.bermuda.const import SWITCH
 
+# Not currently used - commenting out
+# async def test_switch_services(hass: HomeAssistant):
+#     """Test switch services."""
+#     # Create a mock entry so we don't have to go through config flow
+#     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
+#     assert await async_setup_entry(hass, config_entry)
+#     await hass.async_block_till_done()
 
-async def test_switch_services(hass):
-    """Test switch services."""
-    # Create a mock entry so we don't have to go through config flow
-    config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test")
-    assert await async_setup_entry(hass, config_entry)
-    await hass.async_block_till_done()
+# Functions/objects can be patched directly
+# in test code as well and can be used to test
+# additional things, like whether a function
+# was called or what arguments it was called with
+# with patch(
+#     "custom_components.bermuda.BermudaDataUpdateCoordinator.async_set_title"
+# ) as title_func:
+#     await hass.services.async_call(
+#         SWITCH,
+#         SERVICE_TURN_OFF,
+#         service_data={ATTR_ENTITY_ID: f"{SWITCH}.{DEFAULT_NAME}_{SWITCH}"},
+#         blocking=True,
+#     )
+#     assert title_func.called
+#     assert title_func.call_args == call("foo")
 
-    # Functions/objects can be patched directly
-    # in test code as well and can be used to test
-    # additional things, like whether a function
-    # was called or what arguments it was called with
-    # with patch(
-    #     "custom_components.bermuda.BermudaDataUpdateCoordinator.async_set_title"
-    # ) as title_func:
-    #     await hass.services.async_call(
-    #         SWITCH,
-    #         SERVICE_TURN_OFF,
-    #         service_data={ATTR_ENTITY_ID: f"{SWITCH}.{DEFAULT_NAME}_{SWITCH}"},
-    #         blocking=True,
-    #     )
-    #     assert title_func.called
-    #     assert title_func.call_args == call("foo")
+#     title_func.reset_mock()
 
-    #     title_func.reset_mock()
-
-    #     await hass.services.async_call(
-    #         SWITCH,
-    #         SERVICE_TURN_ON,
-    #         service_data={ATTR_ENTITY_ID: f"{SWITCH}.{DEFAULT_NAME}_{SWITCH}"},
-    #         blocking=True,
-    #     )
-    #     assert title_func.called
-    #     assert title_func.call_args == call("bar")
+#     await hass.services.async_call(
+#         SWITCH,
+#         SERVICE_TURN_ON,
+#         service_data={ATTR_ENTITY_ID: f"{SWITCH}.{DEFAULT_NAME}_{SWITCH}"},
+#         blocking=True,
+#     )
+#     assert title_func.called
+#     assert title_func.call_args == call("bar")


### PR DESCRIPTION
Changes:
- Removed async_setup - when configuration setup isn't done in yaml, it doesn't need to exist.
- Changed to OptionsFlowwithConfigEntry
- Created two fixtures to get either a mockconfigentry or a mock config entry that has been set up
- Changed how setup of entries works
- Instead of directly calling functions in init, we now use hass to call them

I will have to change either this Pr or the other depending on which gets merged first