### PR TITLE
feat: Config status and Calibration additions

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -9,12 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
-
-# from homeassistant.helpers.device_registry import EventDeviceRegistryUpdatedData
 from homeassistant.helpers.device_registry import DeviceEntry, format_mac
 
 from .const import _LOGGER, DOMAIN, PLATFORMS, STARTUP_MESSAGE
@@ -24,23 +20,8 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
-# from .const import _LOGGER_SPAM_LESS
-
-# from typing import TYPE_CHECKING
-
-# from bthome_ble import BTHomeBluetoothDeviceData
-
-# if TYPE_CHECKING:
-#     from bleak.backends.device import BLEDevice
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-
-
-# async def async_setup(
-#     hass: HomeAssistant, config: Config
-# ):  # pylint: disable=unused-argument;
-#     """Setting up this integration using YAML is not supported."""
-#     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/custom_components/bermuda/bermuda_device_scanner.py
+++ b/custom_components/bermuda/bermuda_device_scanner.py
@@ -17,7 +17,7 @@ from .const import (
     CONF_DEVICES,
     CONF_MAX_VELOCITY,
     CONF_REF_POWER,
-    CONF_RSSI_OFFSET,
+    CONF_RSSI_OFFSETS,
     CONF_SMOOTHING_SAMPLES,
     DISTANCE_INFINITE,
     DISTANCE_TIMEOUT,
@@ -143,7 +143,7 @@ class BermudaDeviceScanner(dict):
             self.rssi = scandata.advertisement.rssi
             self.hist_rssi.insert(0, self.rssi)
             self.rssi_distance_raw = rssi_to_metres(
-                self.rssi + options.get(CONF_RSSI_OFFSET, {}).get(self.scanner_device_name, 0),
+                self.rssi + options.get(CONF_RSSI_OFFSETS, {}).get(self.scanner_device_name, 0),
                 options.get(CONF_REF_POWER),
                 options.get(CONF_ATTENUATION),
             )

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -127,7 +127,7 @@ DOCS[CONF_REF_POWER] = "Default RSSI for signal at 1 metre."
 
 CONF_SAVE_AND_CLOSE = "save_and_close"
 CONF_SCANNER_INFO = "scanner_info"
-CONF_RSSI_OFFSET = "rssi_offset"
+CONF_RSSI_OFFSETS = "rssi_offset"
 
 CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL = "update_interval", 10
 DOCS[CONF_UPDATE_INTERVAL] = (

--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -20,7 +20,7 @@
   "options": {
     "step": {
       "init": {
-        "description": "Bermuda can currently see {device_count} bluetooth devices, reported across {scanner_count} bluetooth scanner devices. {status}"
+        "description": "Bermuda can currently see:\n- {device_count} bluetooth devices.\n- {scanner_count} bluetooth scanner devices.\n\n{status}"
       },
       "globalopts": {
         "data": {
@@ -49,7 +49,7 @@
       },
       "calibration1_global": {
         "title": "Calibration 1: Global",
-        "description": "Choose your most common beacon and your most common scanner to use as a 'reference pair' to calibrate to each other and establish global defaults. \n\n{suffix}",
+        "description": "This step is to establish some global defaults for distance calculations.\n\n{details}\n{summary}\nExpand for instructions!{summary_end}\n\nIn later steps you can set per-device overrides, so it makes sense to choose your most common hardware as a 'reference pair' for this step. For example, if most of your scanners are ESPHome on a particular board, then choose one of those to use as the reference scanner. Likewise if you have a handful of a particular model of beacon, use one of those as your reference device.\n\n- Choose a device and a scanner below to use as your 'reference pair'\n- Physically place your chosen device at 1m (one metre) from the chosen scanner. Ensure they have a clear line of sight to each other, and avoid having them close to any organic life-forms which might interfere with the signal.\n- Click 'SUBMIT' and note the RSSI values in the table that will appear below. You can click 'SUBMIT' again at any time to refresh the values.\n- Once you have a stable signal strength, put that value into the `reference_power` field and click 'SUBMIT'.\n- You should now see the updated values, and the estimated distances should be close to 1 metre. Repeat as required until you are happy with the result.\n- Now move the device so that it is further from the scanner and measure this distance with a tape measure. Around 5 metres might be a good distance - the exact distance doesn't matter, but keeping a clear line of sight is important, and you might find longer distances will give you more accuracy, generally.\n- With the device at the new distance, click 'SUBMIT' again and you should see the most recent measurements will reflect the new distance, but will probably be inaccurate.\n- Experiment with different values for `attenuation` and clicking 'SUBMIT', until you get the estimated measurements to agree with your physical measurement.\n- Once you are happy with the calibration, tick 'Save and Close' and click 'SUBMIT'.\n{details_end}\n{suffix}",
         "data": {
           "configured_devices": "Device",
           "configured_scanners": "Scanner",
@@ -63,7 +63,7 @@
           "ref_power": "To calibrate this setting, place the device 1 metre from the scanner, and adjust the value until the figures above reflect that 1m distance. Note that values will only recompute after clicking submit, and a more-negative number will result in a lower distance"
         }
       },
-      "calibration2_scanner": {
+      "calibration2_scanners": {
         "title": "Calibration 2: Per-Scanner",
         "description": "This step is optional but useful if your scanners have different sensitivities or varying antenna performance. Adjust the offset rssi for each scanner until the calculated distance to the selected device is correct. It is best not to change the offset for the scanner you used as part of the \"reference pair\" in step 1.\n\n{suffix}",
         "data": {


### PR DESCRIPTION
- Add table and nicer formatting to initial config dialog status info.
- Add tables and instructions to calibration steps to make choosing values easier
- Error checking and mac case-folding in _get_bermuda_device_from_registry
- pluralise CONF_RSSI_OFFSET
- add typing to coordinator.scanner_list
- add coordinator.get_active_scanner_summary
- add (copious) instructions to calibration1
- pluralise step name calibration2_scanners