### PR TITLE
Further Calibration improvements

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -160,7 +160,6 @@ class BermudaDevice(dict):
                 self.address,
                 discoveryinfo,  # the entire BluetoothScannerDevice struct
                 scanner_device.area_id or "area_not_defined",
-                self.options,
             )
         else:
             self.scanners[format_mac(scanner_device.address)] = BermudaDeviceScanner(
@@ -168,7 +167,7 @@ class BermudaDevice(dict):
                 discoveryinfo,  # the entire BluetoothScannerDevice struct
                 scanner_device.area_id or "area_not_defined",
                 self.options,
-                scanner_device.name,
+                scanner_device,
             )
         device_scanner = self.scanners[format_mac(scanner_device.address)]
         # Let's see if we should update our last_seen based on this...

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -127,7 +127,7 @@ DOCS[CONF_REF_POWER] = "Default RSSI for signal at 1 metre."
 
 CONF_SAVE_AND_CLOSE = "save_and_close"
 CONF_SCANNER_INFO = "scanner_info"
-CONF_RSSI_OFFSETS = "rssi_offset"
+CONF_RSSI_OFFSETS = "rssi_offsets"
 
 CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL = "update_interval", 10
 DOCS[CONF_UPDATE_INTERVAL] = (

--- a/custom_components/bermuda/diagnostics.py
+++ b/custom_components/bermuda/diagnostics.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.bluetooth.api import _get_manager
 from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import DOMAIN
@@ -22,8 +21,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
     # We can call this with our own config_entry because the diags step doesn't
     # actually use it.
 
-    bt_manager = _get_manager(hass)
-    bt_diags = await bt_manager.async_diagnostics()
+    bt_diags = await coordinator._manager.async_diagnostics()  # noqa
 
     # Param structure for service call
     call = ServiceCall(DOMAIN, "dump_devices", {"redact": True})

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -104,6 +104,7 @@ class BermudaEntity(CoordinatorEntity):
         # seem to be stored uppercased.
         # existing_device_id = None
         domain_name = DOMAIN
+        model = None
 
         if self._device.is_scanner:
             connection = {(dr.CONNECTION_NETWORK_MAC, self._device.address.lower())}
@@ -111,10 +112,14 @@ class BermudaEntity(CoordinatorEntity):
             # ibeacon doesn't (yet) actually set a "connection", but
             # this "matches" what it stores for identifier.
             connection = {("ibeacon", self._device.address.lower())}
+            model = f"iBeacon: {self._device.address.lower()}"
         elif self._device.address_type == ADDR_TYPE_PRIVATE_BLE_DEVICE:
             # Private BLE Device integration doesn't specify "connection" tuples,
             # so we use what it defines for the "identifier" instead.
             connection = {("private_ble_device", self._device.address.lower())}
+            # We don't set the model since the Private BLE integration should have
+            # already named it nicely.
+            # model = f"IRK: {self._device.address.lower()[:4]}"
             # We look up and use the device from the registry so we get
             # the private_ble_device device congealment!
             # The "connection" is actually being used as the "identifiers" tuple
@@ -125,14 +130,20 @@ class BermudaEntity(CoordinatorEntity):
             domain_name = DOMAIN_PRIVATE_BLE_DEVICE
         else:
             connection = {(dr.CONNECTION_BLUETOOTH, self._device.address.upper())}
+            # No need to set model, since MAC address will be shown via connection.
+            # model = f"Bermuda: {self._device.address.lower()}"
 
-        return {
+        device_info = {
             "identifiers": {(domain_name, self._device.unique_id)},
             "connections": connection,
             "name": self._device.prefname,
         }
+        if model is not None:
+            device_info["model"] = model
         # if existing_device_id is not None:
         #    device_info['id'] = existing_device_id
+
+        return device_info
 
     @property
     def device_state_attributes(self):

--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -64,15 +64,15 @@
         }
       },
       "calibration2_scanners": {
-        "title": "Calibration 2: Per-Scanner",
-        "description": "This step is optional but useful if your scanners have different sensitivities or varying antenna performance. Adjust the offset rssi for each scanner until the calculated distance to the selected device is correct. It is best not to change the offset for the scanner you used as part of the \"reference pair\" in step 1.\n\n{suffix}",
+        "title": "Calibration 2: Per-Scanner RSSI Offsets",
+        "description": "This step is optional but useful if your scanners have different sensitivities or varying antenna performance. Adjust the offset rssi for each scanner until the calculated distance to the selected device is correct. Leave the scanner you used in your \"reference pair\" in step 1 at Zero.\n\n{suffix}",
         "data": {
           "configured_devices": "Device",
           "save_and_close": "Save and Close",
-          "scanner_info": "Scanner info"
+          "scanner_info": "Per-Scanner RSSI Offsets"
         },
         "data_description": {
-          "scanner_info": "Enter a non-zero number to offset the rssi reported by that scanner. Adjust until the estimated distance above matches the actual distance between that scanner and the selected transmitting device."
+          "scanner_info": "Leave at zero to accept the global default, or enter a non-zero number to offset the rssi reported by that scanner. Adjust until the estimated distance above matches the actual distance between that scanner and the selected transmitting device. Negative values will increase the distance, positive values will decrease it."
         }
       }
     }


### PR DESCRIPTION
- Tidy of diagnostic tables in options_flow
- Add model to device entries to help identify un-named devices
- Label and text tweaks
- Switch to a linear options_flow, looping back to menu caused processing to break.
- Handle where selected device has not been see by selected scanner
- Translate scanner names back to addresses for saving in options
- Flattened ObjectSelector yaml block for scanner offsets
- Cleaned some BermudaDeviceScanner stuff