### PR TITLE
Convert to runtime_data

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -87,7 +87,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: BermudaConfigEntry) -> 
     """Handle removal of an entry."""
     if unload_result := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         _LOGGER.debug("Unloaded platforms.")
-        hass.data[DOMAIN].pop(entry.entry_id)
     return unload_result
 
 

--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -57,7 +57,7 @@ async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: BermudaConfigEntry, device_entry: DeviceEntry
 ) -> bool:
     """Remove a config entry from a device."""
-    coordinator: BermudaDataUpdateCoordinator = config_entry.runtime_data
+    coordinator: BermudaDataUpdateCoordinator = config_entry.runtime_data.coordinator
     address = None
     for ident in device_entry.identifiers:
         try:

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -135,7 +135,7 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
 
     async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument
         """Manage the options."""
-        self.coordinator = self.config_entry.runtime_data
+        self.coordinator = self.config_entry.runtime_data.coordinator
         self.devices = self.coordinator.devices
 
         messages = {}

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.bluetooth import MONOTONIC_TIME, BluetoothServiceInfoBleak
-from homeassistant.config_entries import ConfigEntry, OptionsFlowWithConfigEntry
+from homeassistant.config_entries import OptionsFlowWithConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.selector import (
@@ -50,9 +50,9 @@ from .const import (
 from .util import rssi_to_metres
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.data_entry_flow import FlowResult
 
+    from . import BermudaConfigEntry
     from .bermuda_device import BermudaDevice
     from .coordinator import BermudaDataUpdateCoordinator
 
@@ -122,7 +122,7 @@ class BermudaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
     """Config flow options handler for bermuda."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self, config_entry: BermudaConfigEntry) -> None:
         """Initialize HACS options flow."""
         super().__init__(config_entry)
         self.coordinator: BermudaDataUpdateCoordinator
@@ -135,7 +135,7 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
 
     async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument
         """Manage the options."""
-        self.coordinator = self.hass.data[DOMAIN][self.config_entry.entry_id]
+        self.coordinator = self.config_entry.runtime_data
         self.devices = self.coordinator.devices
 
         messages = {}
@@ -234,7 +234,7 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
             return await self._update_options()
 
         # Grab the co-ordinator's device list so we can build a selector from it.
-        self.devices = self.hass.data[DOMAIN][self.config_entry.entry_id].devices
+        self.devices = self.config_entry.runtime_data.coordinator.devices
 
         # Where we store the options before building the selector
         options_list = []

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1113,7 +1113,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
             # A) we have a new scanner
             # B) It has been 30 minutes since our last update
             if (
-                len(self.config_entry.data[CONFDATA_SCANNERS]) != len(confdata_scanners)
+                len(self.config_entry.data.get(CONFDATA_SCANNERS, {})) != len(confdata_scanners)
                 or self.last_config_entry_update is None
                 or (now() - self.last_config_entry_update).total_seconds() > 1800
             ):

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -10,25 +10,25 @@ from homeassistant.const import STATE_HOME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import DOMAIN, SIGNAL_DEVICE_NEW
+from .const import SIGNAL_DEVICE_NEW
 from .entity import BermudaEntity
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+    from . import BermudaConfigEntry
     from .coordinator import BermudaDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: BermudaConfigEntry,
     async_add_devices: AddEntitiesCallback,
 ) -> None:
     """Load Device Tracker entities for a config entry."""
-    coordinator: BermudaDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: BermudaDataUpdateCoordinator = entry.runtime_data.coordinator
 
     created_devices = []  # list of devices we've already created entities for
 

--- a/custom_components/bermuda/diagnostics.py
+++ b/custom_components/bermuda/diagnostics.py
@@ -9,14 +9,13 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from .const import DOMAIN
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
-
+    from . import BermudaConfigEntry
     from .coordinator import BermudaDataUpdateCoordinator
 
 
-async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
+async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: BermudaConfigEntry) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: BermudaDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: BermudaDataUpdateCoordinator = entry.runtime_data.coordintor
 
     # We can call this with our own config_entry because the diags step doesn't
     # actually use it.

--- a/custom_components/bermuda/diagnostics.py
+++ b/custom_components/bermuda/diagnostics.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: BermudaConfigEntry) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: BermudaDataUpdateCoordinator = entry.runtime_data.coordintor
+    coordinator: BermudaDataUpdateCoordinator = entry.runtime_data.coordinator
 
     # We can call this with our own config_entry because the diags step doesn't
     # actually use it.

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -21,10 +21,8 @@ from .const import (
 )
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
-
+    from . import BermudaConfigEntry
     from .coordinator import BermudaDataUpdateCoordinator
-
     # from . import BermudaDevice
 
 
@@ -39,7 +37,7 @@ class BermudaEntity(CoordinatorEntity):
     def __init__(
         self,
         coordinator: BermudaDataUpdateCoordinator,
-        config_entry: ConfigEntry,
+        config_entry: BermudaConfigEntry,
         address: str,
     ) -> None:
         super().__init__(coordinator)
@@ -161,7 +159,7 @@ class BermudaGlobalEntity(CoordinatorEntity):
     def __init__(
         self,
         coordinator: BermudaDataUpdateCoordinator,
-        config_entry: ConfigEntry,
+        config_entry: BermudaConfigEntry,
     ) -> None:
         super().__init__(coordinator)
         self.coordinator = coordinator

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -19,7 +19,6 @@ from .const import (
     _LOGGER,
     ADDR_TYPE_IBEACON,
     ADDR_TYPE_PRIVATE_BLE_DEVICE,
-    DOMAIN,
     SIGNAL_DEVICE_NEW,
 )
 from .entity import BermudaEntity, BermudaGlobalEntity
@@ -27,19 +26,19 @@ from .entity import BermudaEntity, BermudaGlobalEntity
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
-    from homeassistant import config_entries
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+    from . import BermudaConfigEntry
     from .coordinator import BermudaDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: BermudaConfigEntry,
     async_add_devices: AddEntitiesCallback,
 ) -> None:
     """Setup sensor platform."""
-    coordinator: BermudaDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: BermudaDataUpdateCoordinator = entry.runtime_data.coordinator
 
     created_devices = []  # list of already-created devices
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from unittest.mock import patch
+from homeassistant.config_entries import ConfigEntryState
 
 import pytest
 from homeassistant.core import HomeAssistant
@@ -99,5 +100,5 @@ async def setup_bermuda_entry(hass: HomeAssistant):
     config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, entry_id="test", title=NAME)
     config_entry.add_to_hass(hass)
     await async_setup_component(hass, DOMAIN, {})
-    assert DOMAIN in hass.data and config_entry.entry_id in hass.data[DOMAIN]
+    assert config_entry.state == ConfigEntryState.LOADED
     return config_entry

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -32,7 +32,7 @@ async def test_setup_unload_and_reload_entry(
 
     # Unload the entry and verify that the data has been removed
     assert await hass.config_entries.async_unload(setup_bermuda_entry.entry_id)
-    assert setup_bermuda_entry.entry_id == ConfigEntryState.NOT_LOADED
+    assert setup_bermuda_entry.state == ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_entry_exception(hass, error_on_get_data):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -11,6 +11,7 @@ from custom_components.bermuda.const import DOMAIN
 from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
 
 from .const import MOCK_CONFIG
+from homeassistant.config_entries import ConfigEntryState
 
 # from pytest_homeassistant_custom_component.common import AsyncMock
 
@@ -24,16 +25,14 @@ async def test_setup_unload_and_reload_entry(
     hass: HomeAssistant, bypass_get_data, setup_bermuda_entry: MockConfigEntry
 ):
     """Test entry setup and unload."""
-    assert isinstance(hass.data[DOMAIN][setup_bermuda_entry.entry_id], BermudaDataUpdateCoordinator)
 
     # Reload the entry and assert that the data from above is still there
     assert await hass.config_entries.async_reload(setup_bermuda_entry.entry_id)
-    assert DOMAIN in hass.data and setup_bermuda_entry.entry_id in hass.data[DOMAIN]
-    assert isinstance(hass.data[DOMAIN][setup_bermuda_entry.entry_id], BermudaDataUpdateCoordinator)
+    assert setup_bermuda_entry.state == ConfigEntryState.LOADED
 
     # Unload the entry and verify that the data has been removed
     assert await hass.config_entries.async_unload(setup_bermuda_entry.entry_id)
-    assert setup_bermuda_entry.entry_id not in hass.data[DOMAIN]
+    assert setup_bermuda_entry.entry_id == ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_entry_exception(hass, error_on_get_data):


### PR DESCRIPTION
- Change to use runtime_data instead of hass.data
- Limit the amount of times that we update the config flow.