### PR TITLE
feat: Add Nearest scanner entity_id sensor

### DIFF
--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -158,6 +158,9 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
         self._entity_registry = er.async_get(self.hass)
         self._device_registry = dr.async_get(self.hass)
 
+        # Add storage for scanner entity IDs
+        self.scanner_entity_ids: dict[str, str] = {}
+
         # Track the list of Private BLE devices, noting their entity id
         # and current "last address".
         self.pb_state_sources: dict[str, str | None] = {}
@@ -1105,6 +1108,9 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
         _previous_scannerlist = [device.address for device in self.devices.values() if device.is_scanner]
         _purge_scanners = _previous_scannerlist.copy()
 
+        # Clear existing mappings to ensure fresh start
+        self.scanner_entity_ids.clear()
+
         # _LOGGER.error("Preserving %d current scanner entries", len(_previous_scannerlist))
 
         # Find active HaBaseScanners in the backend, and only pay attention to those
@@ -1132,6 +1138,28 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
                     hascanner.source,
                 )
                 continue
+
+            if scanner_devreg:
+                _LOGGER.debug("Found device entry id: %s", scanner_devreg.id)
+
+                # Get all entities for this device
+                entities = list(self._entity_registry.entities.get_entries_for_device_id(scanner_devreg.id))
+
+                if len(entities) > 1:
+                    # Device must have multiple entities. Reduce search space
+                    entities = [entity for entity in entities if entity.domain in ("switch", "light")]
+                if entities:
+                    # Take the first valid entity
+                    self.scanner_entity_ids[scanner_address] = entities[0].entity_id
+                    _LOGGER.debug(
+                        "Mapped scanner %s (%s) to entity %s",
+                        scanner_devreg.name,
+                        scanner_address,
+                        entities[0].entity_id,
+                    )
+                else:
+                    _LOGGER.debug("No entity found for scanner %s", scanner_address)
+
             # _LOGGER.info("Great! Found scanner: %s (%s)", scanner_ha.name, scanner_ha.source)
             # Since this scanner still exists, we won't purge it
             if scanner_address in _purge_scanners:

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -173,6 +173,24 @@ class BermudaSensorScanner(BermudaSensor):
     def native_value(self):
         return self._device.area_scanner
 
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        """Return extra state attributes for the nearest scanner."""
+        attribs = super().extra_state_attributes or {}
+
+        if self._device.area_scanner:
+            for scanner in self.coordinator.scanner_list:
+                scanner_device = self.coordinator.devices[scanner]
+                if scanner_device.address.upper() in self._device.area_scanner:
+                    if scanner_device.address in self.coordinator.scanner_entity_ids:
+                        attribs["scanner_entity_id"] = self.coordinator.scanner_entity_ids[scanner_device.address]
+                        _LOGGER.debug(
+                            "Set scanner_entity_id to %s for device %s", attribs["scanner_entity_id"], self._device.name
+                        )
+                    break
+
+        return attribs
+
 
 class BermudaSensorRssi(BermudaSensor):
     """Sensor for RSSI of closest scanner."""


### PR DESCRIPTION
This adds an additional sensor that tracks the entity_id of the nearest scanner. Having the raw entity_id allows you to perform downstream tasks on the scanner entity, such as retrieve all associated labels, get state attributes, etc.

Most of my scanners are Shelly 1 Plus relays controlling light switches. The switch location is not always the same area as the lights it controls (e.g. inside switch controlling outside lights). Exposing the raw entity_id of the nearest scanner lets be use custom attributes or labels in my dashboards.

I've added a custom attribute (switch_location) to each Shelly device, and am instead using this in my dashboards:
`Phone is near {{ state_attr(states(entity), 'friendly_name') }} ({{ state_attr(states(entity), 'switch_location') }})`

Alternatively, the same can be done using Labels (I've used a prefix "switch_location_[VALUE]"):
`Phone is near {{ state_attr(states(entity), 'friendly_name') }} ({{ (labels(states('sensor.phone_nearest_scanner_entity')) | select('match', '^switch_location_.*') | first).replace('switch_location_', '') }})`