### PR TITLE
fix: IRK devices temporary unavail on mac rotation fixes #362

### DIFF
--- a/custom_components/bermuda/bermuda_device_scanner.py
+++ b/custom_components/bermuda/bermuda_device_scanner.py
@@ -401,7 +401,10 @@ class BermudaDeviceScanner(dict):
                         velocity,
                     )
                 # Discard the bogus reading by duplicating the last.
-                self.hist_distance_by_interval.insert(0, self.hist_distance_by_interval[0])
+                if len(self.hist_distance_by_interval) == 0:
+                    self.hist_distance_by_interval = [self.rssi_distance_raw]
+                else:
+                    self.hist_distance_by_interval.insert(0, self.hist_distance_by_interval[0])
             else:
                 # Looks valid enough, add the current reading to the interval log
                 self.hist_distance_by_interval.insert(0, self.rssi_distance_raw)


### PR DESCRIPTION
- Fixes Devices go unavailable every few mins for a few seconds #362
- Fix insert when velo_max is exceeded but the hist_distance_by_interval was empty (such as after MAC rotation)