### PR TITLE
Add 'Area Last Seen' and 'Last Seen' sensors

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -61,6 +61,8 @@ class BermudaDevice(dict):
         self.address_type = BDADDR_TYPE_UNKNOWN
         self.area_id: str | None = None
         self.area_name: str | None = None
+        self.area_last_seen: str | None = None
+
         self.area_distance: float | None = None  # how far this dev is from that area
         self.area_rssi: float | None = None  # rssi from closest scanner
         self.area_scanner: str | None = None  # name of closest scanner
@@ -174,6 +176,7 @@ class BermudaDevice(dict):
             self.area_distance = closest_scanner.rssi_distance
             self.area_rssi = closest_scanner.rssi
             self.area_scanner = closest_scanner.name
+            self.area_last_seen = closest_scanner.area_name
         else:
             # Not close to any scanners!
             self.area_id = None

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -319,6 +319,7 @@ class BermudaSensorScannerRangeRaw(BermudaSensorScannerRange):
             return round(distance, 3)
         return None
 
+
 class BermudaSensorAreaLastSeen(BermudaSensor):
     """Sensor for name of last seen area."""
 
@@ -334,6 +335,7 @@ class BermudaSensorAreaLastSeen(BermudaSensor):
     def native_value(self):
         return self._device.area_last_seen
 
+
 class BermudaGlobalSensor(BermudaGlobalEntity, SensorEntity):
     """bermuda Global Sensor class."""
 
@@ -348,6 +350,7 @@ class BermudaGlobalSensor(BermudaGlobalEntity, SensorEntity):
     def device_class(self):
         """Return de device class of the sensor."""
         return "bermuda__custom_device_class"
+
 
 class BermudaTotalProxyCount(BermudaGlobalSensor):
     """Counts the total number of proxies we have access to."""

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -59,7 +59,6 @@ async def async_setup_entry(
             entities.append(BermudaSensorScanner(coordinator, entry, address))
             entities.append(BermudaSensorRssi(coordinator, entry, address))
             entities.append(BermudaSensorAreaLastSeen(coordinator, entry, address))
-            entities.append(BermudaSensorLastSeen(coordinator, entry, address))
 
             for scanner in scanners:
                 entities.append(BermudaSensorScannerRange(coordinator, entry, address, scanner))
@@ -334,25 +333,6 @@ class BermudaSensorAreaLastSeen(BermudaSensor):
     @property
     def native_value(self):
         return self._device.area_last_seen
-
-class BermudaSensorLastSeen(BermudaSensor):
-    """Sensor for device last seen time."""
-
-    @property
-    def unique_id(self):
-        return f"{self._device.unique_id}_last_seen"
-
-    @property
-    def name(self):
-        return "Last Seen"
-
-    @property
-    def native_value(self):
-        return self.coordinator.dt_mono_to_datetime(self._device.last_seen)
-
-    @property
-    def device_class(self):
-        return "timestamp"
 
 class BermudaGlobalSensor(BermudaGlobalEntity, SensorEntity):
     """bermuda Global Sensor class."""

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -58,6 +58,7 @@ async def async_setup_entry(
             entities.append(BermudaSensorRange(coordinator, entry, address))
             entities.append(BermudaSensorScanner(coordinator, entry, address))
             entities.append(BermudaSensorRssi(coordinator, entry, address))
+            entities.append(BermudaSensorAreaLastSeen(coordinator, entry, address))
 
             for scanner in scanners:
                 entities.append(BermudaSensorScannerRange(coordinator, entry, address, scanner))
@@ -317,6 +318,22 @@ class BermudaSensorScannerRangeRaw(BermudaSensorScannerRange):
         if distance is not None:
             return round(distance, 3)
         return None
+
+class BermudaSensorAreaLastSeen(BermudaSensor):
+    """Sensor for name of last seen area."""
+
+    @property
+    def unique_id(self):
+        return f"{self._device.unique_id}_area_last_seen"
+
+    @property
+    def name(self):
+        return "Area Last Seen"
+
+    @property
+    def native_value(self):
+        return self._device.area_last_seen
+
 
 
 class BermudaGlobalSensor(BermudaGlobalEntity, SensorEntity):

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -59,6 +59,7 @@ async def async_setup_entry(
             entities.append(BermudaSensorScanner(coordinator, entry, address))
             entities.append(BermudaSensorRssi(coordinator, entry, address))
             entities.append(BermudaSensorAreaLastSeen(coordinator, entry, address))
+            entities.append(BermudaSensorLastSeen(coordinator, entry, address))
 
             for scanner in scanners:
                 entities.append(BermudaSensorScannerRange(coordinator, entry, address, scanner))
@@ -334,7 +335,24 @@ class BermudaSensorAreaLastSeen(BermudaSensor):
     def native_value(self):
         return self._device.area_last_seen
 
+class BermudaSensorLastSeen(BermudaSensor):
+    """Sensor for device last seen time."""
 
+    @property
+    def unique_id(self):
+        return f"{self._device.unique_id}_last_seen"
+
+    @property
+    def name(self):
+        return "Last Seen"
+
+    @property
+    def native_value(self):
+        return self.coordinator.dt_mono_to_datetime(self._device.last_seen)
+
+    @property
+    def device_class(self):
+        return "timestamp"
 
 class BermudaGlobalSensor(BermudaGlobalEntity, SensorEntity):
     """bermuda Global Sensor class."""
@@ -350,7 +368,6 @@ class BermudaGlobalSensor(BermudaGlobalEntity, SensorEntity):
     def device_class(self):
         """Return de device class of the sensor."""
         return "bermuda__custom_device_class"
-
 
 class BermudaTotalProxyCount(BermudaGlobalSensor):
     """Counts the total number of proxies we have access to."""


### PR DESCRIPTION
Fixes #202 

This change adds a new Area Last Seen sensor that contains the last area seen. It is the same as 'Area' but is not reset to 'None'.

This change also exposes the existing last_seen property as a Last Seen timestamp sensor. 

These sensors are disabled by default by the existing logic in the base classes.

Please let me know if there is a different way you imagined this to be implemented or if this is the wrong time stamp or whatever.