### PR TITLE
feat: raise repair for scanners without areas

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -267,4 +267,4 @@ class BermudaDevice(dict):
 
     def __repr__(self) -> str:
         """Help debug devices and figure out what device it is at a glance."""
-        return self.prefname
+        return self.prefname or self.local_name or self.name or self.address

--- a/custom_components/bermuda/bermuda_device_scanner.py
+++ b/custom_components/bermuda/bermuda_device_scanner.py
@@ -376,7 +376,7 @@ class BermudaDeviceScanner(dict):
                         velocity = delta_d / delta_t
 
                         # Don't use max() as it's slower.
-                        if velocity > peak_velocity:
+                        if velocity > peak_velocity:  # noqa: PLR1730
                             # but on subsequent comparisons we only care if they're faster retreats
                             peak_velocity = velocity
                 # we've been through the history and have peak velo retreat, or the most recent

--- a/custom_components/bermuda/bermuda_device_scanner.py
+++ b/custom_components/bermuda/bermuda_device_scanner.py
@@ -376,7 +376,7 @@ class BermudaDeviceScanner(dict):
                         velocity = delta_d / delta_t
 
                         # Don't use max() as it's slower.
-                        if velocity > peak_velocity:  # noqa: PLR1730
+                        if velocity > peak_velocity:  # noqa: RUF100, PLR1730
                             # but on subsequent comparisons we only care if they're faster retreats
                             peak_velocity = velocity
                 # we've been through the history and have peak velo retreat, or the most recent

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -24,6 +24,9 @@ ISSUE_URL = "https://github.com/agittins/bermuda/issues"
 # Icons
 ICON = "mdi:format-quote-close"
 
+# Issue/repair translation keys. If you change these you MUST also update the key in the translations/xx.json files.
+REPAIR_SCANNER_WITHOUT_AREA = "scanner_without_area"
+
 # Device classes
 BINARY_SENSOR_DEVICE_CLASS = "connectivity"
 

--- a/custom_components/bermuda/translations/en.json
+++ b/custom_components/bermuda/translations/en.json
@@ -113,5 +113,11 @@
         }
       }
     }
+  },
+  "issues": {
+    "scanner_without_area": {
+      "title": "Some Bluetooth Proxies don't have an AREA",
+      "description": "Bermuda requires all bluetooth proxies to have a valid area assigned in order to work correctly. Assign an area by visiting each proxy's device page (via `Devices and Services`), and click the pencil icon in the top-right to assign an area. The following proxies are missing an area assignment:\n\n{scannerlist}"
+    }
   }
 }


### PR DESCRIPTION
If scanners are found that don't have an area assigned to them,
a repair issue is raised to advise the user to do so.