### PR TITLE
feat: Flag Area sensor if scanner area is invalid

### DIFF
--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1225,6 +1225,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
                     areas,
                 )
                 _scanners_without_areas.append(scanner_b.name or scanner_b.address)
+                scanner_b.area_name = f"Invalid Area for {scanner_b.name}"
             scanner_b.is_scanner = True
 
         # Now un-tag any devices that are no longer scanners


### PR DESCRIPTION
When a scanner does not have a valid area set
and the device is closest to that scanner, set
the area sensor to `Invalid Area for [scanner.name]`, which will hopefully encourage looking at the repair issue!