### PR TITLE
fix: regression from v0.7.3 hist..dist..interval

### DIFF
--- a/custom_components/bermuda/bermuda_device_scanner.py
+++ b/custom_components/bermuda/bermuda_device_scanner.py
@@ -401,7 +401,7 @@ class BermudaDeviceScanner(dict):
                 else:
                     self.hist_distance_by_interval.insert(0, self.hist_distance_by_interval[0])
             else:
-                self.hist_distance_by_interval.insert(0, self.hist_distance_by_interval[0])
+                self.hist_distance_by_interval.insert(0, self.rssi_distance_raw)
 
             # trim the log to length
             if len(self.hist_distance_by_interval) > self.conf_smoothing_samples:
@@ -427,6 +427,8 @@ class BermudaDeviceScanner(dict):
                 movavg = dist_total / _hist_dist_len
             else:
                 movavg = local_min
+
+            # Finally, set the new, smoothed rssi_distance value.
             # The average is only helpful if it's lower than the actual reading.
             if self.rssi_distance_raw is None or movavg < self.rssi_distance_raw:
                 self.rssi_distance = movavg


### PR DESCRIPTION
fixes #463
Performance improvement patch caused hist_distance_by_interval to only include duplicated values, and also lead
to index errors in some circumstances.
This also caused the smoothing to break, causing
more area switching than previous releases.