### PR TITLE
refactor!: fixed naming of devices for consistency

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -17,6 +17,7 @@ import re
 from homeassistant.components.bluetooth import MONOTONIC_TIME, BluetoothScannerDevice
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.util import slugify
 
 from .bermuda_device_scanner import BermudaDeviceScanner
 from .const import (
@@ -33,6 +34,7 @@ from .const import (
     CONF_DEVICES,
     CONF_DEVTRACK_TIMEOUT,
     DEFAULT_DEVTRACK_TIMEOUT,
+    DOMAIN,
 )
 
 
@@ -50,9 +52,11 @@ class BermudaDevice(dict):
 
     def __init__(self, address, options) -> None:
         """Initial (empty) data."""
-        self.name: str | None = None
-        self.local_name: str | None = None
-        self.prefname: str | None = None  # "preferred" name - ideally local_name
+        self.name: str = f"{DOMAIN}_{slugify(address)}"  # "preferred" name built by Bermuda.
+        self.name_bt_serviceinfo: str | None = None  # From serviceinfo.device.name
+        self.name_bt_local_name: str | None = None  # From service_info.advertisement.local_name
+        self.name_devreg: str | None = None  # From device registry, for other integrations like scanners, pble devices
+        self.name_by_user: str | None = None  # Any user-defined (in the HA UI) name discovered for a device.
         self.address: str = address
         self.ref_power: float = 0  # If non-zero, use in place of global ref_power.
         self.ref_power_changed: float = 0  # Stamp for last change to ref_power, for cache zapping.
@@ -65,7 +69,7 @@ class BermudaDevice(dict):
 
         self.area_distance: float | None = None  # how far this dev is from that area
         self.area_rssi: float | None = None  # rssi from closest scanner
-        self.area_scanner: str | None = None  # name of closest scanner
+        self.area_scanner: BermudaDeviceScanner | None = None  # currently closest BermudaScanner
         self.zone: str = STATE_UNAVAILABLE  # STATE_HOME or STATE_NOT_HOME
         self.manufacturer: str | None = None
         self.connectable: bool = False
@@ -131,6 +135,33 @@ class BermudaDevice(dict):
             else:
                 self.address_type = BDADDR_TYPE_OTHER
 
+    def make_name(self):
+        """
+        Refreshes self.name and returns it, based on naming preferences.
+
+        Will prefer the friendly names sent by bluetooth advert, but will fall back
+        to manufacturer name and bluetooth address.
+        """
+        _newname = (
+            self.name_by_user
+            or self.name_devreg
+            or self.name_bt_local_name
+            or self.name_bt_serviceinfo
+            or self.beacon_unique_id
+        )
+
+        if _newname is not None:
+            self.name = _newname
+        else:
+            # Couldn't find anything nice, we'll have to use the address.
+            if self.manufacturer:
+                _prefix = f"{slugify(self.manufacturer)}"
+            else:
+                _prefix = DOMAIN
+            self.name = f"{_prefix}_{slugify(self.address)}"
+
+        return self.name
+
     def set_ref_power(self, new_ref_power: float):
         """
         Set a new reference power for this device and immediately apply
@@ -171,19 +202,19 @@ class BermudaDevice(dict):
         old_area = self.area_name
         if closest_scanner is not None:
             # We found a winner
+            self.area_scanner = closest_scanner
             self.area_id = closest_scanner.area_id
             self.area_name = closest_scanner.area_name
             self.area_distance = closest_scanner.rssi_distance
             self.area_rssi = closest_scanner.rssi
-            self.area_scanner = closest_scanner.name
             self.area_last_seen = closest_scanner.area_name
         else:
             # Not close to any scanners!
+            self.area_scanner = None
             self.area_id = None
             self.area_name = None
             self.area_distance = None
             self.area_rssi = None
-            self.area_scanner = None
         if (old_area != self.area_name) and self.create_sensor:
             # Our area has changed!
             _LOGGER.debug(
@@ -270,4 +301,4 @@ class BermudaDevice(dict):
 
     def __repr__(self) -> str:
         """Help debug devices and figure out what device it is at a glance."""
-        return self.prefname or self.local_name or self.name or self.address
+        return self.name

--- a/custom_components/bermuda/bermuda_device_scanner.py
+++ b/custom_components/bermuda/bermuda_device_scanner.py
@@ -392,7 +392,7 @@ class BermudaDeviceScanner(dict):
                 if self.parent_device_address.upper() in self.options.get(CONF_DEVICES, []):
                     _LOGGER.debug(
                         "This sparrow %s flies too fast (%2fm/s), ignoring",
-                        self.parent_device_address,
+                        self.parent_device.name,
                         velocity,
                     )
                 # Discard the bogus reading by duplicating the last.

--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -51,7 +51,7 @@ from .const import (
 from .util import rssi_to_metres
 
 if TYPE_CHECKING:
-    from homeassistant.data_entry_flow import FlowResult
+    from homeassistant.config_entries import ConfigFlowResult
 
     from . import BermudaConfigEntry
     from .bermuda_device import BermudaDevice
@@ -72,7 +72,7 @@ class BermudaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Initialize."""
         self._errors = {}
 
-    async def async_step_bluetooth(self, discovery_info: BluetoothServiceInfoBleak) -> FlowResult:
+    async def async_step_bluetooth(self, discovery_info: BluetoothServiceInfoBleak) -> ConfigFlowResult:
         """
         Support automatic initiation of setup through bluetooth discovery.
         (we still show a confirmation form to the user, though)
@@ -175,8 +175,8 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
                 status = '<ha-icon icon="mdi:skull-crossbones"></ha-icon>'
 
             scanner_table += (
-                f"| {scanner.get("name", "NAME_ERR")}| [{scanner.get("address", "ADDR_ERR")}]"
-                f"| {status} {int(scanner.get("last_stamp_age", DISTANCE_INFINITE)):d} seconds ago.|\n"
+                f"| {scanner.get('name', 'NAME_ERR')}| [{scanner.get('address', 'ADDR_ERR')}]"
+                f"| {status} {int(scanner.get('last_stamp_age', DISTANCE_INFINITE)):d} seconds ago.|\n"
             )
         messages["status"] += scanner_table
 
@@ -249,7 +249,7 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
         for device in self.devices.values():
             # Iterate through all the discovered devices to build the options list
 
-            name = device.prefname or device.name or ""
+            name = device.name
 
             if device.is_scanner:
                 # We don't "track" scanner devices, per se
@@ -268,7 +268,7 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
                     SelectOptionDict(
                         value=device.address.upper(),
                         label=f"iBeacon: {device.address.upper()} {source_mac} "
-                        f"{name if device.address.upper() != name.upper() else ""}",
+                        f"{name if device.address.upper() != name.upper() else ''}",
                     )
                 )
                 continue

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -82,7 +82,8 @@ class BermudaDeviceTracker(BermudaEntity, BaseTrackerEntity):
     @property
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return extra state attributes for this device."""
-        return {"scanner": self._device.area_scanner, "area": self._device.area_name}
+        _scannername = self._device.area_scanner.name if self._device.area_scanner else None
+        return {"scanner": _scannername, "area": self._device.area_name}
 
     @property
     def state(self) -> str:


### PR DESCRIPTION
- These changes might break integrations that are relying on the names of devices or entities, or on the naming structure of the bermuda.dump_devices output. Those relying on unique_id etc should not be affected.
- Fixed some issues where devices names did not have good defaults.
- change bermuda_device to store object of closest scanner, rather than just its name.
- tidy/clarify area selection logic.
- remove scanner list from _refresh_scanners params
- remove log warning about newly init metadevices fixes #405