### PR TITLE
feat: Restore Area Last Seen on HA restart, fix Area not timing out

### DIFF
--- a/custom_components/bermuda/config_flow.py
+++ b/custom_components/bermuda/config_flow.py
@@ -259,8 +259,8 @@ class BermudaOptionsFlowHandler(OptionsFlowWithConfigEntry):
                 continue
             if device.address_type == ADDR_TYPE_IBEACON:
                 # This is an iBeacon meta-device
-                if len(device.beacon_sources) > 0:
-                    source_mac = f"[{device.beacon_sources[0].upper()}]"
+                if len(device.metadevice_sources) > 0:
+                    source_mac = f"[{device.metadevice_sources[0].upper()}]"
                 else:
                     source_mac = ""
 

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -67,10 +67,12 @@ LOGSPAM_INTERVAL = 22
 # originators of beacon-like data. We then create a "meta-device" for the beacon's
 # uuid. Other non-static-mac protocols should use this method as well, by adding their
 # own BEACON_ types.
-BEACON_IBEACON_SOURCE: Final = "beacon source"  # The source-device sending a beacon packet (MAC-tracked)
+METADEVICE_TYPE_IBEACON_SOURCE: Final = "beacon source"  # The source-device sending a beacon packet (MAC-tracked)
 BEACON_IBEACON_DEVICE: Final = "beacon device"  # The meta-device created to track the beacon
-BEACON_PRIVATE_BLE_SOURCE: Final = "private_ble_src"  # current (random) MAC of a private ble device
+METADEVICE_TYPE_PRIVATE_BLE_SOURCE: Final = "private_ble_src"  # current (random) MAC of a private ble device
 BEACON_PRIVATE_BLE_DEVICE: Final = "private_ble_device"  # meta-device create to track private ble device
+
+METADEVICE_SOURCETYPES: Final = {METADEVICE_TYPE_IBEACON_SOURCE, METADEVICE_TYPE_PRIVATE_BLE_SOURCE}
 
 # Bluetooth Device Address Type - classify MAC addresses
 BDADDR_TYPE_UNKNOWN: Final = "bd_addr_type_unknown"  # uninitialised

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import RestoreSensor, SensorEntity
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -320,7 +320,7 @@ class BermudaSensorScannerRangeRaw(BermudaSensorScannerRange):
         return None
 
 
-class BermudaSensorAreaLastSeen(BermudaSensor):
+class BermudaSensorAreaLastSeen(BermudaSensor, RestoreSensor):
     """Sensor for name of last seen area."""
 
     @property
@@ -334,6 +334,13 @@ class BermudaSensorAreaLastSeen(BermudaSensor):
     @property
     def native_value(self):
         return self._device.area_last_seen
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last saved value before adding to HASS."""
+        await super().async_added_to_hass()
+        if (sensor_data := await self.async_get_last_sensor_data()) is not None:
+            self._attr_native_value = str(sensor_data.native_value)
+            self._device.area_last_seen = str(sensor_data.native_value)
 
 
 class BermudaGlobalSensor(BermudaGlobalEntity, SensorEntity):

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -142,8 +142,8 @@ class BermudaSensor(BermudaEntity, SensorEntity):
             ADDR_TYPE_IBEACON,
             ADDR_TYPE_PRIVATE_BLE_DEVICE,
         ]:
-            if len(self._device.beacon_sources) > 0:
-                current_mac = self._device.beacon_sources[0]
+            if len(self._device.metadevice_sources) > 0:
+                current_mac = self._device.metadevice_sources[0]
             else:
                 current_mac = STATE_UNAVAILABLE
 


### PR DESCRIPTION
The "Area Last Seen" sensor (if enabled) now restores state after a HA restart. Note that the state is only saved periodically by HA and on graceful shutdown, so a power outage etc might not reflect the most recent state on restart.

Also included:
- fix for the Area sensor sometimes remaining locked
to area instead of returning to unknown, likely
due to simplifications made in recent commits.
- feat: only calculate nearest-area for tracked devices
- refactor: renamed beacon_type to metadevice_type
- chore: comment cleaning, linting