### PR TITLE
fix: iOS flipping to unknown indeterminately

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pylint]
+max-line-length=120
+
 # Adapted from https://github.com/ludeeus/integration_blueprint/blob/main/.ruff.toml
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
- This hopefully fixes #375
- New iOS (18.3+ I think) sends a flurry of BLE broadcasts at different times (mostly screen [un]lock) using *different* MAC addresses. Their order appears not very deterministic, so previous addresses will often appear on future updates.
- Bermuda now registers a callback with PBD integration so we get realtime updates on new MACs, so we don't miss any between update runs. As we store the recent MACs this resolves the issue.
- First clue was Android15 doing a similar thing, but its address- cycling was slower.
- Linting, tidying. Also chilled pylint on line-length.