### PR TITLE
Ajg dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,12 +3,17 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "HomeAssistant(debug)",
+      "name": "Home Assistant (debug)",
       "type": "debugpy",
       "request": "launch",
-      "justMyCode": false,
       "module": "homeassistant",
-      "args": ["--debug", "-c", "config"]
+      "justMyCode": false,
+      "args": [
+        "--debug",
+        "-c",
+        "/workspaces/homeassistant-core/config"
+      ],
+      // "preLaunchTask": "Compile English translations"
     },
     // This is the old (attempted) config of attaching to an already-running
     // instance, but I couldn't get breakpoints to work in the custom_component.
@@ -28,9 +33,27 @@
     //     }
     //   ]
     // },
+    // {
+    //   // Example of attaching to my production server
+    //   "name": "Python: Attach Remote",
+    //   "type": "debugpy",
+    //   "request": "attach",
+    //   "connect": {
+    //     "port": 5678,
+    //     "host": "homeassistant.home"
+    //   },
+    //   "pathMappings": [
+    //     {
+    //       "localRoot": "${workspaceFolder}",
+    //       "remoteRoot": "/config"
+    //     }
+    //   ]
+    // },
     {
-      // Example of attaching to my production server
-      "name": "Python: Attach Remote",
+      // Debug by attaching to remote Home Assistant server using Remote Python Debugger.
+      // See https://www.home-assistant.io/integrations/debugpy/
+      // This nearly works now.
+      "name": "AJG Home Remote",
       "type": "debugpy",
       "request": "attach",
       "connect": {
@@ -38,9 +61,18 @@
         "host": "homeassistant.home"
       },
       "pathMappings": [
+        // This maps the HA devcontainer paths to match the HAOS paths
         {
-          "localRoot": "${workspaceFolder}",
+          "localRoot": "/workspaces/homeassistant-core/config",
           "remoteRoot": "/config"
+        },
+        {
+          "localRoot": "/workspaces/homeassistant-core",
+          "remoteRoot": "/usr/src/homeassistant"
+        },
+        {
+          "localRoot": "/workspaces/repo-bermuda/custom_components/bermuda",
+          "remoteRoot": "/config/custom_components/bermuda"
         }
       ]
     }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "python.pythonPath": "venv/bin/python",
+  "python.pythonPath": "/home/vscode/.local/ha-venv/bin/python",
   "files.associations": {
     "*.yaml": "home-assistant"
   },
@@ -7,5 +7,7 @@
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
   "python.analysis.typeCheckingMode": "basic",
-  "python.analysis.autoImportCompletions": true
+  "python.analysis.autoImportCompletions": true,
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -870,19 +870,25 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
             # We need to find more addresses to prune. Perhaps we live
             # in a busy train station, or are under some sort of BLE-MAC
             # DOS-attack.
-            # Sort the prunables by timestamp ascending
-            sorted_addresses = sorted([(v, k) for k, v in prunable_stamps.items()])
-            cutoff = min(len(sorted_addresses), prune_quota_shortfall)
+            if len(prunable_stamps) > 0:
+                # Sort the prunables by timestamp ascending
+                sorted_addresses = sorted([(v, k) for k, v in prunable_stamps.items()])
+                cutoff_index = min(len(sorted_addresses), prune_quota_shortfall)
 
-            _LOGGER.info(
-                "Prune quota short by %d. Pruning %d extra devices (down to age %d seconds)",
-                prune_quota_shortfall,
-                cutoff,
-                nowstamp - sorted_addresses[prune_quota_shortfall][0],
-            )
-            # pylint: disable-next=unused-variable
-            for _stamp, address in sorted_addresses[:prune_quota_shortfall]:
-                prune_list.append(address)
+                _LOGGER.debug(
+                    "Prune quota short by %d. Pruning %d extra devices (down to age %0.2f seconds)",
+                    prune_quota_shortfall,
+                    cutoff_index,
+                    nowstamp - sorted_addresses[prune_quota_shortfall - 1][0],
+                )
+                # pylint: disable-next=unused-variable
+                for _stamp, address in sorted_addresses[: prune_quota_shortfall - 1]:
+                    prune_list.append(address)
+            else:
+                _LOGGER.warning(
+                    "Need to prune another %s devices to make quota, but no extra prunables available",
+                    prune_quota_shortfall,
+                )
 
         # ###############################################
         # Prune_list is now ready to action. It contains no keepers, and is already

--- a/scripts/develop
+++ b/scripts/develop
@@ -10,12 +10,12 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-#if [[ ! -f venv/bin/activate ]]; then
-#    echo "ERROR: No venv, make sure you run setup first!"
-#    exit 1
-#fi
-#
-#source venv/bin/activate
+if [[ ! -f "$VENV/bin/activate" ]]; then
+    echo "ERROR: No venv, make sure you run setup first!"
+    exit 1
+fi
+
+source $VENV/bin/activate
 
 
 # Create config dir if not present

--- a/scripts/setup
+++ b/scripts/setup
@@ -5,20 +5,26 @@ set -e
 cd "$(dirname "$0")/.."
 
 # Create a virtual environment
-# AJG - actually, don't. Thought it was a good idea but it breaks
-# code completion etc because it seems vscode doesn't/won't run in
-# that context. Or I'm an idiot, just as likely.
 #
-# Note that this setup script gets run on container init so everything
-# should be ready to go on loading.
+# If you're using vscode, this is where the venv lives that it will
+# call by default.
+export VENV=/home/vscode/.local/ha-venv
 #
-#python3 -m venv venv
-#source venv/bin/activate
+# If you're running closer to the metal, you might prefer this
+# instead:
+# export VENV=venv
+
+# Hopefully prioritise finding bermuda sources in our
+# working dir while debugging, rather than in the HA tree.
+export PYTHONPATH="${PWD}/custom_components:${PYTHONPATH}"
+
+python3 -m venv $VENV
+source $VENV/bin/activate
 
 # Seems to fix broken aiohttp wheel building in 3.11:
-python3 -m pip install --upgrade setuptools wheel
+uv pip install --upgrade setuptools wheel
 # Fix urllib3 issue https://github.com/home-assistant/core/issues/95192
-python3 -m pip install git+https://github.com/boto/botocore
+uv pip install git+https://github.com/boto/botocore
 
-python3 -m pip install --requirement requirements.txt
-python3 -m pip install --requirement requirements_test.txt
+uv pip install --requirement requirements.txt
+uv pip install --requirement requirements_test.txt


### PR DESCRIPTION
fix: #534 pruning index out of range

- Fix off-by-one index errors in prune_devices check for prunable_stamps
- Fix index errors when there are no prunable_stamps

chore: Improve vscode and devcontainer debug setup

- use `uv` for pip requirements.
- Change debugpy calls to work with remote debugging HAOS
- settings.json to use devcontainer's venv in ~/vscode/.local/ha-env
  Also explicitly disabled unittests, enabled pytest per copilot req.
- configure scripts/setup and scripts/develop to allow setting venv
  location with $VENV, default to devcontainer's ~/vscode/.local...