### PR TITLE
feat: Area and distance entities use area icon

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -81,9 +81,11 @@ class BermudaDevice(dict):
         self.options = self._coordinator.options
         self.unique_id: str | None = None  # mac address formatted.
         self.address_type = BDADDR_TYPE_UNKNOWN
+
         self.area_id: str | None = None
         self.area_name: str | None = None
         self.area_last_seen: str | None = None
+        self.area_last_seen_id: str | None = None
 
         self.area_distance: float | None = None  # how far this dev is from that area
         self.area_rssi: float | None = None  # rssi from closest scanner
@@ -257,6 +259,7 @@ class BermudaDevice(dict):
             self.area_distance = closest_scanner.rssi_distance
             self.area_rssi = closest_scanner.rssi
             self.area_last_seen = closest_scanner.area_name
+            self.area_last_seen_id = closest_scanner.area_id
         else:
             # Not close to any scanners, or closest scanner has timed out!
             self.area_scanner = None

--- a/custom_components/bermuda/sensor.py
+++ b/custom_components/bermuda/sensor.py
@@ -135,6 +135,30 @@ class BermudaSensor(BermudaEntity, SensorEntity):
         return self._device.area_name
 
     @property
+    def icon(self):
+        """Provide a custom icon for particular entities."""
+        # TODO: This is ugly doing a check on name, and is a kludge
+        # because I originally was a bit reckless with the multiple
+        # inheritance here. So all the sensors should be restructured
+        # a bit to clean up this and other properties.
+        if (
+            self.name in ["Area"]
+            and self._device.area_id
+            and (area := self.area_reg.async_get_area(self._device.area_id))
+            and area.icon
+        ):
+            return area.icon
+        if (
+            self.name in ["Area Last Seen"]
+            and self._device.area_last_seen_id
+            and (area := self.area_reg.async_get_area(self._device.area_last_seen_id))
+            and area.icon
+        ):
+            return area.icon
+        return super().icon
+        # return "mdi:floor-plan" or "mdi:map-marker-distance" or "mdi:signal-distance-variant"
+
+    @property
     def entity_registry_enabled_default(self) -> bool:
         """Declare if entity should be automatically enabled on adding."""
         return self.name in ["Area", "Distance"]


### PR DESCRIPTION
- If an area has an icon defined, Bermuda will use that icon for the Area, Distance, and Last Seen Area
entities.