### PR TITLE
feat: significant restructuring

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -102,16 +102,16 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: BermudaConfigEn
 async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: BermudaConfigEntry, device_entry: DeviceEntry
 ) -> bool:
-    """Remove a config entry from a device."""
+    """Implements user-deletion of devices from device registry."""
     coordinator: BermudaDataUpdateCoordinator = config_entry.runtime_data.coordinator
     address = None
-    for ident in device_entry.identifiers:
+    for domain, ident in device_entry.identifiers:
         try:
-            if ident[0] == DOMAIN:
+            if domain == DOMAIN:
                 # the identifier should be the base device address, and
                 # may have "_range" or some other per-sensor suffix.
                 # The address might be a mac address, IRK or iBeacon uuid
-                address = ident[1].split("_")[0]
+                address = ident.split("_")[0]
         except KeyError:
             pass
     if address is not None:
@@ -139,4 +139,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: BermudaConfigEntry) -> 
 
 async def async_reload_entry(hass: HomeAssistant, entry: BermudaConfigEntry) -> None:
     """Reload config entry."""
-    await hass.config_entries.async_reload(entry.entry_id)
+    hass.config_entries.async_schedule_reload(entry.entry_id)

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import logging
 from typing import Final
 
+from homeassistant.const import Platform
+
 from .log_spam_less import BermudaLogSpamLess
 
 NAME = "Bermuda BLE Trilateration"
@@ -31,20 +33,21 @@ REPAIR_SCANNER_WITHOUT_AREA = "scanner_without_area"
 BINARY_SENSOR_DEVICE_CLASS = "connectivity"
 
 # Platforms
-BINARY_SENSOR = "binary_sensor"
-BUTTON = "button"
-SENSOR = "sensor"
-SWITCH = "switch"
-DEVICE_TRACKER = "device_tracker"
-NUMBER = "number"
-# PLATFORMS = [BINARY_SENSOR, SENSOR, SWITCH]
-PLATFORMS = [SENSOR, DEVICE_TRACKER, NUMBER]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.DEVICE_TRACKER,
+    Platform.NUMBER,
+    # Platform.BUTTON,
+    # Platform.SWITCH,
+    # Platform.BINARY_SENSOR
+]
 
 # Should probably retreive this from the component, but it's in "DOMAIN" *shrug*
 DOMAIN_PRIVATE_BLE_DEVICE = "private_ble_device"
 
 # Signal names we are using:
 SIGNAL_DEVICE_NEW = f"{DOMAIN}-device-new"
+SIGNAL_SCANNERS_CHANGED = f"{DOMAIN}-scanners-changed"
 
 UPDATE_INTERVAL = 1.05  # Seconds between bluetooth data processing cycles
 # Note: this is separate from the CONF_UPDATE_INTERVAL which allows the
@@ -76,11 +79,14 @@ METADEVICE_TYPE_PRIVATE_BLE_SOURCE: Final = "private_ble_src"  # current (random
 METADEVICE_PRIVATE_BLE_DEVICE: Final = "private_ble_device"  # meta-device create to track private ble device
 
 METADEVICE_SOURCETYPES: Final = {METADEVICE_TYPE_IBEACON_SOURCE, METADEVICE_TYPE_PRIVATE_BLE_SOURCE}
+METADEVICE_DEVICETYPES: Final = {METADEVICE_IBEACON_DEVICE, METADEVICE_PRIVATE_BLE_DEVICE}
 
 # Bluetooth Device Address Type - classify MAC addresses
 BDADDR_TYPE_UNKNOWN: Final = "bd_addr_type_unknown"  # uninitialised
 BDADDR_TYPE_OTHER: Final = "bd_addr_other"  # Default 48bit MAC
-BDADDR_TYPE_PRIVATE_RESOLVABLE: Final = "bd_addr_private_resolvable"
+BDADDR_TYPE_RANDOM_RESOLVABLE: Final = "bd_addr_random_resolvable"
+BDADDR_TYPE_RANDOM_UNRESOLVABLE: Final = "bd_addr_random_unresolvable"
+BDADDR_TYPE_RANDOM_STATIC: Final = "bd_addr_random_static"
 BDADDR_TYPE_NOT_MAC48: Final = "bd_addr_not_mac48"
 # Non-bluetooth address types - for our metadevice entries
 ADDR_TYPE_IBEACON: Final = "addr_type_ibeacon"

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -33,7 +33,7 @@ async def async_setup_entry(
     created_devices = []  # list of devices we've already created entities for
 
     @callback
-    def device_new(address: str, scanners: list[str]) -> None:  # pylint: disable=unused-argument
+    def device_new(address: str) -> None:
         """
         Create entities for newly-found device.
 

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.bluetooth import MONOTONIC_TIME
+from bluetooth_data_tools import monotonic_time_coarse
 from homeassistant.core import callback
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
@@ -66,7 +66,7 @@ class BermudaEntity(CoordinatorEntity):
         if interval is not None:
             self.bermuda_update_interval = interval
 
-        nowstamp = MONOTONIC_TIME()
+        nowstamp = monotonic_time_coarse()
         if (
             (self.bermuda_last_stamp < nowstamp - self.bermuda_update_interval)  # Cache is stale
             or (self._device.ref_power_changed > nowstamp + 2)  # ref power changed in last 2sec
@@ -205,7 +205,7 @@ class BermudaGlobalEntity(CoordinatorEntity):
         """A simple way to rate-limit sensor updates."""
         if interval is not None:
             self._cache_ratelimit_interval = interval
-        nowstamp = MONOTONIC_TIME()
+        nowstamp = monotonic_time_coarse()
 
         if nowstamp > self._cache_ratelimit_stamp + self._cache_ratelimit_interval:
             self._cache_ratelimit_stamp = nowstamp

--- a/custom_components/bermuda/log_spam_less.py
+++ b/custom_components/bermuda/log_spam_less.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant.components.bluetooth import MONOTONIC_TIME
+from bluetooth_data_tools import monotonic_time_coarse
 
 if TYPE_CHECKING:
     import logging
@@ -37,11 +37,11 @@ class BermudaLogSpamLess:
         if key in self._keycache:
             # key exists, check timestamps
             cache = self._keycache[key]
-            if cache["stamp"] < MONOTONIC_TIME() - self._interval:
+            if cache["stamp"] < monotonic_time_coarse() - self._interval:
                 # It's time to emit the message
                 count = cache["count"]
                 cache["count"] = 0
-                cache["stamp"] = MONOTONIC_TIME()
+                cache["stamp"] = monotonic_time_coarse()
                 return count
             # We sent this message recently, don't spam
             cache["count"] += 1
@@ -49,7 +49,7 @@ class BermudaLogSpamLess:
         else:
             # Key is completely new, store the new stamp and let it through
             self._keycache[key] = {
-                "stamp": MONOTONIC_TIME(),
+                "stamp": monotonic_time_coarse(),
                 "count": 0,
             }
             return 0

--- a/custom_components/bermuda/manufacturer_identification/company_identifiers.yaml
+++ b/custom_components/bermuda/manufacturer_identification/company_identifiers.yaml
@@ -1,0 +1,11419 @@
+company_identifiers:
+
+  - value: 0x0EE0
+    name: 'MAERSK CONTAINER INDUSTRY A/S'
+
+  - value: 0x0EDF
+    name: 'Dynaudio A/S'
+
+  - value: 0x0EDE
+    name: 'Sony Honda Mobility Inc.'
+
+  - value: 0x0EDD
+    name: 'Ceridwen Limited'
+
+  - value: 0x0EDC
+    name: 'Shenzhen Zoqin Technology Co., Ltd.'
+
+  - value: 0x0EDB
+    name: 'ShenZhen BoYiChuangXin'
+
+  - value: 0x0EDA
+    name: 'Kodira GmbH'
+
+  - value: 0x0ED9
+    name: 'Overhead Door Corporation'
+
+  - value: 0x0ED8
+    name: 'DORAN MFG. LLC'
+
+  - value: 0x0ED7
+    name: 'CS INSTRUMENTS GmbH & Co.KG'
+
+  - value: 0x0ED6
+    name: 'Quintessential Design, Inc.'
+
+  - value: 0x0ED5
+    name: 'Relish Technologies Limited'
+
+  - value: 0x0ED4
+    name: 'Goerdyna Group Co., Ltd'
+
+  - value: 0x0ED3
+    name: 'Lichens Innovation inc.'
+
+  - value: 0x0ED2
+    name: 'SHENZHEN BESTWAY ELECTRONICS CO.,LTD'
+
+  - value: 0x0ED1
+    name: 'VINYL MATT MEDIA LIMITED'
+
+  - value: 0x0ED0
+    name: 'Gibson, Inc.'
+
+  - value: 0x0ECF
+    name: 'GGEC America, Inc.'
+
+  - value: 0x0ECE
+    name: 'Guangzhou Honor Microelectronic Co.,Ltd.'
+
+  - value: 0x0ECD
+    name: 'Nature Inc.'
+
+  - value: 0x0ECC
+    name: 'Shenzhen NEOECO Technology Co., Ltd.'
+
+  - value: 0x0ECB
+    name: 'Zhong Shan City Richsound Electronic Industrial Ltd.'
+
+  - value: 0x0ECA
+    name: 'NexRev LLC'
+
+  - value: 0x0EC9
+    name: 'NeuroPace Inc'
+
+  - value: 0x0EC8
+    name: 'Codie LLC'
+
+  - value: 0x0EC7
+    name: 'Canyon Bicycles GmbH'
+
+  - value: 0x0EC6
+    name: 'AuthGate B.V.'
+
+  - value: 0x0EC5
+    name: 'Alibaba (China) Co., Ltd.'
+
+  - value: 0x0EC4
+    name: 'PACIFIC MARINE BATTERIES PTY. LIMITED'
+
+  - value: 0x0EC3
+    name: 'Herschel Infrared Ltd'
+
+  - value: 0x0EC2
+    name: 'High Entropy, LLC'
+
+  - value: 0x0EC1
+    name: 'Crossdoor'
+
+  - value: 0x0EC0
+    name: 'WEST inx Ltd.'
+
+  - value: 0x0EBF
+    name: 'Schulte-Schlagbaum AG'
+
+  - value: 0x0EBE
+    name: 'Deity Acoustic Technology Co.'
+
+  - value: 0x0EBD
+    name: 'Tongfang Health Technology (Beijing) Co., Ltd.'
+
+  - value: 0x0EBC
+    name: 'GP Acoustics International Limited'
+
+  - value: 0x0EBB
+    name: 'Asahi Denso Co.,Ltd.'
+
+  - value: 0x0EBA
+    name: 'THERMY LTD'
+
+  - value: 0x0EB9
+    name: 'egojin co,.ltd'
+
+  - value: 0x0EB8
+    name: 'PARAGON ID'
+
+  - value: 0x0EB7
+    name: 'Embedded Solutions LLC'
+
+  - value: 0x0EB6
+    name: 'Server Products, Inc.'
+
+  - value: 0x0EB5
+    name: 'Preseed Japan Corporation'
+
+  - value: 0x0EB4
+    name: 'BLUEFIN DATA, LLC'
+
+  - value: 0x0EB3
+    name: 'Zucchetti Axess'
+
+  - value: 0x0EB2
+    name: 'PRADCO Outdoor Brands'
+
+  - value: 0x0EB1
+    name: 'WearNex Limited'
+
+  - value: 0x0EB0
+    name: 'FactorySense'
+
+  - value: 0x0EAF
+    name: 'Unfolded Circle ApS'
+
+  - value: 0x0EAE
+    name: 'BHClears Microelectronics (Shanghai) Co., Ltd.'
+
+  - value: 0x0EAD
+    name: 'OPTRON Co., Ltd.'
+
+  - value: 0x0EAC
+    name: 'Dynetrex Solutions Inc.'
+
+  - value: 0x0EAB
+    name: 'STEYR Sport GmbH'
+
+  - value: 0x0EAA
+    name: 'Hive Soundz inc.'
+
+  - value: 0x0EA9
+    name: 'Makichie Co., Ltd.'
+
+  - value: 0x0EA8
+    name: 'Dongguan Trangjan Industrial Co., Ltd'
+
+  - value: 0x0EA7
+    name: 'BrickXter GmbH'
+
+  - value: 0x0EA6
+    name: 'AMG Lab LLC'
+
+  - value: 0x0EA5
+    name: 'EasyReach Solutions Private Limited'
+
+  - value: 0x0EA4
+    name: 'BiTECH Automotive (Wuhu) Co.,Ltd'
+
+  - value: 0x0EA3
+    name: 'OLIS ELECTRONICS, LLC'
+
+  - value: 0x0EA2
+    name: 'QIKCONNEX LLC'
+
+  - value: 0x0EA1
+    name: 'Culligan International Company'
+
+  - value: 0x0EA0
+    name: 'ENLESS WIRELESS'
+
+  - value: 0x0E9F
+    name: 'Owlet Baby Care Inc.'
+
+  - value: 0x0E9E
+    name: 'Travelxp India Private Limited'
+
+  - value: 0x0E9D
+    name: 'Audinor ApS'
+
+  - value: 0x0E9C
+    name: 'Andrews & Arnold Ltd'
+
+  - value: 0x0E9B
+    name: 'Panasonic Automotive Systems Co., Ltd.'
+
+  - value: 0x0E9A
+    name: 'Scanbro OU'
+
+  - value: 0x0E99
+    name: 'Medibound, Inc.'
+
+  - value: 0x0E98
+    name: 'Chromatic Inc.'
+
+  - value: 0x0E97
+    name: 'kokoromil Inc.'
+
+  - value: 0x0E96
+    name: 'Skeed,co,Ltd.'
+
+  - value: 0x0E95
+    name: 'Viaanix, Inc.'
+
+  - value: 0x0E94
+    name: 'Tactrix'
+
+  - value: 0x0E93
+    name: 'MIV ELECTRONICS, LTD'
+
+  - value: 0x0E92
+    name: 'Glutz AG'
+
+  - value: 0x0E91
+    name: 'Identita Inc.'
+
+  - value: 0x0E90
+    name: 'RainMaker Solutions, Inc.'
+
+  - value: 0x0E8F
+    name: 'Avetos Design LLC'
+
+  - value: 0x0E8E
+    name: 'Nobest Inc'
+
+  - value: 0x0E8D
+    name: 'Celebrities Management Private Limited'
+
+  - value: 0x0E8C
+    name: 'Gopod Group Holding Limited'
+
+  - value: 0x0E8B
+    name: 'Allgon AB'
+
+  - value: 0x0E8A
+    name: 'Tele-Radio i Lysekil AB'
+
+  - value: 0x0E89
+    name: 'Brudden'
+
+  - value: 0x0E88
+    name: 'Skewered Fencing, LLC'
+
+  - value: 0x0E87
+    name: 'OpenTech Alliance, Inc.'
+
+  - value: 0x0E86
+    name: 'Mercury Marine, a division of Brunswick Corporation'
+
+  - value: 0x0E85
+    name: 'TigerLight, Inc.'
+
+  - value: 0x0E84
+    name: 'Tymphany HK Ltd'
+
+  - value: 0x0E83
+    name: 'SPRiNTUS GmbH'
+
+  - value: 0x0E82
+    name: 'CHEVALIER TECH LIMITED'
+
+  - value: 0x0E81
+    name: 'Guangdong Hengqin Xingtong Technology Co.,ltd.'
+
+  - value: 0x0E80
+    name: 'IQNEXXT Solutions GmbH'
+
+  - value: 0x0E7F
+    name: 'SZR-Dev UG'
+
+  - value: 0x0E7E
+    name: 'Archon Controls LLC'
+
+  - value: 0x0E7D
+    name: 'Jiangsu XinTongda Electric Technology Co.,Ltd.'
+
+  - value: 0x0E7C
+    name: 'final Inc.'
+
+  - value: 0x0E7B
+    name: 'Circular'
+
+  - value: 0x0E7A
+    name: 'Vivago Oy'
+
+  - value: 0x0E79
+    name: 'Neptune First OU'
+
+  - value: 0x0E78
+    name: 'HONG KONG COMMUNICATIONS COMPANY LIMITED'
+
+  - value: 0x0E77
+    name: 'MOBILE TECH, INC.'
+
+  - value: 0x0E76
+    name: 'Guangdong Nanguang Photo&Video Systems Co., Ltd.'
+
+  - value: 0x0E75
+    name: 'Le Touch (Shenzhen) Electronics Co., Ltd.'
+
+  - value: 0x0E74
+    name: 'Rocky Radios LLC'
+
+  - value: 0x0E73
+    name: 'Adventures of the Persistently Impaired (and other tales) Limited'
+
+  - value: 0x0E72
+    name: 'TOR.AI LIMITED'
+
+  - value: 0x0E71
+    name: 'ENABLEWEAR LLC'
+
+  - value: 0x0E70
+    name: 'Powerstick.com'
+
+  - value: 0x0E6F
+    name: 'OpConnect, Inc.'
+
+  - value: 0x0E6E
+    name: 'I.M.LAB Inc'
+
+  - value: 0x0E6D
+    name: 'FEVOS LIMITED'
+
+  - value: 0x0E6C
+    name: 'RIGH, INC.'
+
+  - value: 0x0E6B
+    name: 'Shenzhen Goodocom Information Technology Co., Ltd.'
+
+  - value: 0x0E6A
+    name: 'Hyena Inc.'
+
+  - value: 0x0E69
+    name: 'Megatronix (Beijing) Technology Co., Ltd'
+
+  - value: 0x0E68
+    name: 'EarTex Ltd'
+
+  - value: 0x0E67
+    name: 'NEXT DEVICES LTDA'
+
+  - value: 0x0E66
+    name: 'Shenzhen Baseus Technology Co., Ltd.'
+
+  - value: 0x0E65
+    name: 'Daikin Industries, LTD'
+
+  - value: 0x0E64
+    name: 'HuiTong intelligence Company Limited'
+
+  - value: 0x0E63
+    name: 'LAST LOCK INC.'
+
+  - value: 0x0E62
+    name: 'GOKI PTY LTD'
+
+  - value: 0x0E61
+    name: 'Queclink Wireless Solutions Co., Ltd.'
+
+  - value: 0x0E60
+    name: 'Ant Group Co., Ltd.'
+
+  - value: 0x0E5F
+    name: 'Ruptela'
+
+  - value: 0x0E5E
+    name: 'SHAPER TOOLS, INC.'
+
+  - value: 0x0E5D
+    name: 'L.T.H. Electronics Limited'
+
+  - value: 0x0E5C
+    name: 'Amimon Ltd.'
+
+  - value: 0x0E5B
+    name: 'Wuhu Hongjing Electronic Co.,Ltd'
+
+  - value: 0x0E5A
+    name: 'OmniWave Microelectronics Shanghai Co., Ltd'
+
+  - value: 0x0E59
+    name: 'Loewe Technology GmbH'
+
+  - value: 0x0E58
+    name: 'Urban Armor Gear, LLC'
+
+  - value: 0x0E57
+    name: 'Altina Inc.'
+
+  - value: 0x0E56
+    name: 'INEPRO Metering B.V.'
+
+  - value: 0x0E55
+    name: 'New Cosmos Electric Co., Ltd.'
+
+  - value: 0x0E54
+    name: 'Relief Technologies AS'
+
+  - value: 0x0E53
+    name: 'MINIRIG'
+
+  - value: 0x0E52
+    name: 'Aquana, LLC'
+
+  - value: 0x0E51
+    name: 'Dyaco International Inc.'
+
+  - value: 0x0E50
+    name: 'Zhejiang Desman Intelligent Technology Co., Ltd.'
+
+  - value: 0x0E4F
+    name: 'eBet Gaming Sytems Pty Limited'
+
+  - value: 0x0E4E
+    name: 'QSC, LLC'
+
+  - value: 0x0E4D
+    name: 'Brooksee, Inc.'
+
+  - value: 0x0E4C
+    name: 'Luxshare Precision Industry Co., Ltd.'
+
+  - value: 0x0E4B
+    name: 'PUDSEY DIAMOND ENGINEERING LIMITED'
+
+  - value: 0x0E4A
+    name: 'Nitto Denko Corporation'
+
+  - value: 0x0E49
+    name: 'Deone (Shanghai) Communication & Technology Co., Ltd'
+
+  - value: 0x0E48
+    name: 'KARLUNA MUHENDISLIK SANAYI VE TICARET ANONIM SIRKETI'
+
+  - value: 0x0E47
+    name: 'Hosiden Besson Limited'
+
+  - value: 0x0E46
+    name: 'SOUNDUCT'
+
+  - value: 0x0E45
+    name: 'Filo Srl'
+
+  - value: 0x0E44
+    name: 'QUANTATEC'
+
+  - value: 0x0E43
+    name: 'InnoVision Medical Technologies, LLC'
+
+  - value: 0x0E42
+    name: 'Z-ONE Technology Co., Ltd.'
+
+  - value: 0x0E41
+    name: 'Asustek Computer Inc.'
+
+  - value: 0x0E40
+    name: 'WKD Labs Ltd'
+
+  - value: 0x0E3F
+    name: 'Wiser Devices, LLC'
+
+  - value: 0x0E3E
+    name: 'VANBOX'
+
+  - value: 0x0E3D
+    name: 'Walmart Inc.'
+
+  - value: 0x0E3C
+    name: 'Viselabs'
+
+  - value: 0x0E3B
+    name: 'Swift IOT Tech (Shenzhen) Co., LTD.'
+
+  - value: 0x0E3A
+    name: 'OFIVE LIMITED'
+
+  - value: 0x0E39
+    name: 'IRES Infrarot Energie Systeme GmbH'
+
+  - value: 0x0E38
+    name: 'SLOC GmbH'
+
+  - value: 0x0E37
+    name: 'CESYS Gesellschaft für angewandte Mikroelektronik mbH'
+
+  - value: 0x0E36
+    name: 'Cousins and Sears LLC'
+
+  - value: 0x0E35
+    name: 'SNAPPWISH LLC'
+
+  - value: 0x0E34
+    name: 'Vermis, software solutions llc'
+
+  - value: 0x0E33
+    name: 'Crescent NV'
+
+  - value: 0x0E32
+    name: 'PACIFIC INDUSTRIAL CO., LTD.'
+
+  - value: 0x0E31
+    name: 'AlphaTheta Corporation'
+
+  - value: 0x0E30
+    name: 'Primax Electronics Ltd.'
+
+  - value: 0x0E2F
+    name: 'ONWI'
+
+  - value: 0x0E2E
+    name: 'NIHON KOHDEN CORPORATION'
+
+  - value: 0x0E2D
+    name: 'ECARX (Hubei) Tech Co.,Ltd.'
+
+  - value: 0x0E2C
+    name: '9313-7263 Quebec inc.'
+
+  - value: 0x0E2B
+    name: 'JE electronic a/s'
+
+  - value: 0x0E2A
+    name: 'Huizhou Foryou General Electronics Co., Ltd.'
+
+  - value: 0x0E29
+    name: 'Flipper Devices Inc.'
+
+  - value: 0x0E28
+    name: 'PatchRx, Inc.'
+
+  - value: 0x0E27
+    name: 'NextSense, Inc.'
+
+  - value: 0x0E26
+    name: 'LIHJOEN SPEED METER CO., LTD.'
+
+  - value: 0x0E25
+    name: 'Hangzhou Hikvision Digital Technology Co., Ltd.'
+
+  - value: 0x0E24
+    name: 'Avedis Zildjian Co.'
+
+  - value: 0x0E23
+    name: 'MS kajak7 UG (limited liability)'
+
+  - value: 0x0E22
+    name: 'HITO INC'
+
+  - value: 0x0E21
+    name: 'FOGO'
+
+  - value: 0x0E20
+    name: 'CFLAB TEKNOLOJI TICARET LIMITED SIRKETI'
+
+  - value: 0x0E1F
+    name: 'Blecon Ltd'
+
+  - value: 0x0E1E
+    name: '9512-5837 QUEBEC INC.'
+
+  - value: 0x0E1D
+    name: 'Capte B.V.'
+
+  - value: 0x0E1C
+    name: 'SHENZHEN DIGITECH CO., LTD'
+
+  - value: 0x0E1B
+    name: 'Time Location Systems AS'
+
+  - value: 0x0E1A
+    name: 'Sensovo GmbH'
+
+  - value: 0x0E19
+    name: 'Hive-Zox International SA'
+
+  - value: 0x0E18
+    name: 'Hangzhou Microimage Software Co.,Ltd.'
+
+  - value: 0x0E17
+    name: 'Ad Hoc Electronics, llc.'
+
+  - value: 0x0E16
+    name: 'Xiamen RUI YI Da Electronic Technology Co.,Ltd'
+
+  - value: 0x0E15
+    name: 'Eastern Partner Limited'
+
+  - value: 0x0E14
+    name: 'Heilongjiang Tianyouwei Electronics Co.,Ltd.'
+
+  - value: 0x0E13
+    name: 'ASYSTOM'
+
+  - value: 0x0E12
+    name: 'CLEVER LOGGER TECHNOLOGIES PTY LIMITED'
+
+  - value: 0x0E11
+    name: 'Wanzl GmbH & Co. KGaA'
+
+  - value: 0x0E10
+    name: 'Eko Health, Inc.'
+
+  - value: 0x0E0F
+    name: 'SenseWorks Tecnologia Ltda.'
+
+  - value: 0x0E0E
+    name: 'ALOGIC CORPORATION PTY LTD'
+
+  - value: 0x0E0D
+    name: 'FrontAct Co., Ltd.'
+
+  - value: 0x0E0C
+    name: 'Yuanfeng Technology Co., Ltd.'
+
+  - value: 0x0E0B
+    name: 'Sounding Audio Industrial Ltd.'
+
+  - value: 0x0E0A
+    name: 'PRINT INTERNATIONAL LIMITED'
+
+  - value: 0x0E09
+    name: 'Evolutive Systems SL'
+
+  - value: 0x0E08
+    name: 'Heinrich Kopp GmbH'
+
+  - value: 0x0E07
+    name: 'Pinpoint GmbH'
+
+  - value: 0x0E06
+    name: 'iodyne, LLC'
+
+  - value: 0x0E05
+    name: 'SUREPULSE MEDICAL LIMITED'
+
+  - value: 0x0E04
+    name: 'Doro AB'
+
+  - value: 0x0E03
+    name: 'Shenzhen eMeet technology Co.,Ltd'
+
+  - value: 0x0E02
+    name: 'PROSYS DEV LIMITED'
+
+  - value: 0x0E01
+    name: 'Wuhu Mengbo Technology Co., Ltd.'
+
+  - value: 0x0E00
+    name: 'SHENZHEN SOUNDSOUL INFORMATION TECHNOLOGY CO.,LTD'
+
+  - value: 0x0DFF
+    name: 'WaveRF, Corp.'
+
+  - value: 0x0DFE
+    name: 'Haptech, Inc.'
+
+  - value: 0x0DFD
+    name: 'BH Technologies'
+
+  - value: 0x0DFC
+    name: 'SOJI ELECTRONICS JOINT STOCK COMPANY'
+
+  - value: 0x0DFB
+    name: 'Beidou Intelligent Connected Vehicle Technology Co., Ltd.'
+
+  - value: 0x0DFA
+    name: 'Shenzhen Matches IoT Technology Co., Ltd.'
+
+  - value: 0x0DF9
+    name: 'Belusun Technology Ltd.'
+
+  - value: 0x0DF8
+    name: 'Chengdu CSCT Microelectronics Co., Ltd.'
+
+  - value: 0x0DF7
+    name: 'Hangzhou Zhaotong Microelectronics Co., Ltd.'
+
+  - value: 0x0DF6
+    name: 'Mutrack Co., Ltd'
+
+  - value: 0x0DF5
+    name: 'Delta Faucet Company'
+
+  - value: 0x0DF4
+    name: 'REEKON TOOLS INC.'
+
+  - value: 0x0DF3
+    name: 'hDrop Technologies Inc.'
+
+  - value: 0x0DF2
+    name: 'Weber-Stephen Products LLC'
+
+  - value: 0x0DF1
+    name: 'iFLYTEK (Suzhou) Technology Co., Ltd.'
+
+  - value: 0x0DF0
+    name: 'Woncan (Hong Kong) Limited'
+
+  - value: 0x0DEF
+    name: 'SING SUN TECHNOLOGY (INTERNATIONAL) LIMITED'
+
+  - value: 0x0DEE
+    name: 'Safety Swim LLC'
+
+  - value: 0x0DED
+    name: 'Flextronic GmbH'
+
+  - value: 0x0DEC
+    name: 'ATEGENOS PHARMACEUTICALS INC'
+
+  - value: 0x0DEB
+    name: 'Fitz Inc.'
+
+  - value: 0x0DEA
+    name: 'Kathrein Solutions GmbH'
+
+  - value: 0x0DE9
+    name: 'General Laser GmbH'
+
+  - value: 0x0DE8
+    name: 'Vivint, Inc.'
+
+  - value: 0x0DE7
+    name: 'Dendro Technologies, Inc.'
+
+  - value: 0x0DE6
+    name: 'DEXATEK Technology LTD'
+
+  - value: 0x0DE5
+    name: 'Ehong Technology Co.,Ltd'
+
+  - value: 0x0DE4
+    name: 'EMBEINT INC'
+
+  - value: 0x0DE3
+    name: 'Shenzhen MODSEMI Co., Ltd'
+
+  - value: 0x0DE2
+    name: 'TAMADIC Co., Ltd.'
+
+  - value: 0x0DE1
+    name: 'Outshiny India Private Limited'
+
+  - value: 0x0DE0
+    name: 'KNOG PTY. LTD.'
+
+  - value: 0x0DDF
+    name: 'Shenzhen Lunci Technology Co., Ltd'
+
+  - value: 0x0DDE
+    name: 'SHENZHEN DNS INDUSTRIES CO., LTD.'
+
+  - value: 0x0DDD
+    name: 'Tozoa LLC'
+
+  - value: 0x0DDC
+    name: 'AUTHOR-ALARM, razvoj in prodaja avtomobilskih sistemov proti kraji, d.o.o.'
+
+  - value: 0x0DDB
+    name: 'KAGA FEI Co., Ltd.'
+
+  - value: 0x0DDA
+    name: 'Minebea Intec GmbH'
+
+  - value: 0x0DD9
+    name: 'SCHELL GmbH & Co. KG'
+
+  - value: 0x0DD8
+    name: 'Granchip IoT Technology (Guangzhou) Co.,Ltd'
+
+  - value: 0x0DD7
+    name: 'Xiant Technologies, Inc.'
+
+  - value: 0x0DD6
+    name: 'MODULAR MEDICAL, INC.'
+
+  - value: 0x0DD5
+    name: 'BEEPINGS'
+
+  - value: 0x0DD4
+    name: 'KOQOON GmbH & Co.KG'
+
+  - value: 0x0DD3
+    name: 'Global Satellite Engineering'
+
+  - value: 0x0DD2
+    name: 'Sitecom Europe B.V.'
+
+  - value: 0x0DD1
+    name: 'OrangeMicro Limited'
+
+  - value: 0x0DD0
+    name: 'ESNAH'
+
+  - value: 0x0DCF
+    name: 'KUBU SMART LIMITED'
+
+  - value: 0x0DCE
+    name: 'NOVAFON - Electromedical devices limited liability company'
+
+  - value: 0x0DCD
+    name: 'Astra LED AG'
+
+  - value: 0x0DCC
+    name: 'Trotec GmbH'
+
+  - value: 0x0DCB
+    name: 'GEOPH, LLC'
+
+  - value: 0x0DCA
+    name: 'Aptener Mechatronics Private Limited'
+
+  - value: 0x0DC9
+    name: 'farmunited GmbH'
+
+  - value: 0x0DC8
+    name: 'ETO GRUPPE TECHNOLOGIES GmbH'
+
+  - value: 0x0DC7
+    name: 'MORNINGSTAR FX PTE. LTD.'
+
+  - value: 0x0DC6
+    name: 'Levita'
+
+  - value: 0x0DC5
+    name: 'DHL'
+
+  - value: 0x0DC4
+    name: 'Hangzhou NationalChip Science & Technology Co.,Ltd'
+
+  - value: 0x0DC3
+    name: 'GEARBAC TECHNOLOGIES INC.'
+
+  - value: 0x0DC2
+    name: 'Cirrus Research plc'
+
+  - value: 0x0DC1
+    name: 'NACHI-FUJIKOSHI CORP.'
+
+  - value: 0x0DC0
+    name: 'Shenzhen Jahport Electronic Technology Co., Ltd.'
+
+  - value: 0x0DBF
+    name: 'HWM-Water Limited'
+
+  - value: 0x0DBE
+    name: 'HELLA GmbH & Co. KGaA'
+
+  - value: 0x0DBD
+    name: 'MAATEL'
+
+  - value: 0x0DBC
+    name: 'Felion Technologies Company Limited'
+
+  - value: 0x0DBB
+    name: 'Nexis Link Technology Co., Ltd.'
+
+  - value: 0x0DBA
+    name: 'Veo Technologies ApS'
+
+  - value: 0x0DB9
+    name: 'CompanyDeep Ltd'
+
+  - value: 0x0DB8
+    name: 'Shenzhen Chuangyuan Digital Technology Co., Ltd'
+
+  - value: 0x0DB7
+    name: 'Morningstar Corporation'
+
+  - value: 0x0DB6
+    name: 'SAFEGUARD EQUIPMENT, INC.'
+
+  - value: 0x0DB5
+    name: 'Djup AB'
+
+  - value: 0x0DB4
+    name: 'Franklin Control Systems'
+
+  - value: 0x0DB3
+    name: 'SHENZHEN REFLYING ELECTRONIC CO., LTD'
+
+  - value: 0x0DB2
+    name: 'Whirlpool'
+
+  - value: 0x0DB1
+    name: 'TELE System Communications Pte. Ltd.'
+
+  - value: 0x0DB0
+    name: 'Invisalert Solutions, Inc.'
+
+  - value: 0x0DAF
+    name: 'Hexagon Aura Reality AG'
+
+  - value: 0x0DAE
+    name: 'TITUM AUDIO, INC.'
+
+  - value: 0x0DAD
+    name: 'linktop'
+
+  - value: 0x0DAC
+    name: 'ITALTRACTOR ITM S.P.A.'
+
+  - value: 0x0DAB
+    name: 'Efento'
+
+  - value: 0x0DAA
+    name: 'Shenzhen EBELONG Technology Co., Ltd.'
+
+  - value: 0x0DA9
+    name: 'Inventronics GmbH'
+
+  - value: 0x0DA8
+    name: 'Airwallet ApS'
+
+  - value: 0x0DA7
+    name: 'Novoferm tormatic GmbH'
+
+  - value: 0x0DA6
+    name: 'Generac Corporation'
+
+  - value: 0x0DA5
+    name: 'PIXELA CORPORATION'
+
+  - value: 0x0DA4
+    name: 'HP Tuners'
+
+  - value: 0x0DA3
+    name: 'Airgraft Inc.'
+
+  - value: 0x0DA2
+    name: 'KIWI.KI GmbH'
+
+  - value: 0x0DA1
+    name: 'Fen Systems Ltd.'
+
+  - value: 0x0DA0
+    name: 'SICK AG'
+
+  - value: 0x0D9F
+    name: 'MML US, Inc'
+
+  - value: 0x0D9E
+    name: 'Impulse Wellness LLC'
+
+  - value: 0x0D9D
+    name: 'Cear, Inc.'
+
+  - value: 0x0D9C
+    name: 'Skytech Creations Limited'
+
+  - value: 0x0D9B
+    name: 'Boxyz, Inc.'
+
+  - value: 0x0D9A
+    name: 'Yeasound (Xiamen) Hearing Technology Co., Ltd'
+
+  - value: 0x0D99
+    name: 'Caire Inc.'
+
+  - value: 0x0D98
+    name: 'E.F. Johnson Company'
+
+  - value: 0x0D97
+    name: 'Zhejiang Huanfu Technology Co., LTD'
+
+  - value: 0x0D96
+    name: 'NEOKOHM SISTEMAS ELETRONICOS LTDA'
+
+  - value: 0x0D95
+    name: 'Hunter Industries Incorporated'
+
+  - value: 0x0D94
+    name: 'Shrooly Inc'
+
+  - value: 0x0D93
+    name: 'HagerEnergy GmbH'
+
+  - value: 0x0D92
+    name: 'TACHIKAWA CORPORATION'
+
+  - value: 0x0D91
+    name: 'Beamex Oy Ab'
+
+  - value: 0x0D90
+    name: 'LAAS ApS'
+
+  - value: 0x0D8F
+    name: 'Canon Electronics Inc.'
+
+  - value: 0x0D8E
+    name: 'Optivolt Labs, Inc.'
+
+  - value: 0x0D8D
+    name: 'RF Electronics Limited'
+
+  - value: 0x0D8C
+    name: 'Ultimea Technology (Shenzhen) Limited'
+
+  - value: 0x0D8B
+    name: 'Software Development, LLC'
+
+  - value: 0x0D8A
+    name: 'Simply Embedded Inc.'
+
+  - value: 0x0D89
+    name: 'Nanohex Corp'
+
+  - value: 0x0D88
+    name: 'Geocene Inc.'
+
+  - value: 0x0D87
+    name: 'Quectel Wireless Solutions Co., Ltd.'
+
+  - value: 0x0D86
+    name: 'ROCKWELL AUTOMATION, INC.'
+
+  - value: 0x0D85
+    name: 'SEW-EURODRIVE GmbH & Co KG'
+
+  - value: 0x0D84
+    name: 'Testo SE & Co. KGaA'
+
+  - value: 0x0D83
+    name: 'ATLANTIC SOCIETE FRANCAISE DE DEVELOPPEMENT THERMIQUE'
+
+  - value: 0x0D82
+    name: 'VELCO'
+
+  - value: 0x0D81
+    name: 'Beyerdynamic GmbH & Co. KG'
+
+  - value: 0x0D80
+    name: 'Gravaa B.V.'
+
+  - value: 0x0D7F
+    name: 'Konova'
+
+  - value: 0x0D7E
+    name: 'Daihatsu Motor Co., Ltd.'
+
+  - value: 0x0D7D
+    name: 'Taiko Audio B.V.'
+
+  - value: 0x0D7C
+    name: 'BeiJing SmartChip Microelectronics Technology Co.,Ltd'
+
+  - value: 0x0D7B
+    name: 'MindMaze SA'
+
+  - value: 0x0D7A
+    name: 'Xiamen Intretech Inc.'
+
+  - value: 0x0D79
+    name: 'VIVIWARE JAPAN, Inc.'
+
+  - value: 0x0D78
+    name: 'MITACHI CO.,LTD.'
+
+  - value: 0x0D77
+    name: 'DualNetworks SA'
+
+  - value: 0x0D76
+    name: 'i-focus Co.,Ltd'
+
+  - value: 0x0D75
+    name: 'Indistinguishable From Magic, Inc.'
+
+  - value: 0x0D74
+    name: 'ANUME s.r.o.'
+
+  - value: 0x0D73
+    name: 'iota Biosciences, Inc.'
+
+  - value: 0x0D72
+    name: 'Earfun Technology (HK) Limited'
+
+  - value: 0x0D71
+    name: 'Kiteras Inc.'
+
+  - value: 0x0D70
+    name: 'Kindhome'
+
+  - value: 0x0D6F
+    name: 'Closed Joint Stock Company NVP BOLID'
+
+  - value: 0x0D6E
+    name: 'Look Cycle International'
+
+  - value: 0x0D6D
+    name: 'DYNAMOX S/A'
+
+  - value: 0x0D6C
+    name: 'Ambient IoT Pty Ltd'
+
+  - value: 0x0D6B
+    name: 'Crane Payment Innovations, Inc.'
+
+  - value: 0x0D6A
+    name: 'Helge Kaiser GmbH'
+
+  - value: 0x0D69
+    name: 'AIR AROMA INTERNATIONAL PTY LTD'
+
+  - value: 0x0D68
+    name: 'Status Audio LLC'
+
+  - value: 0x0D67
+    name: 'BLACK BOX NETWORK SERVICES INDIA PRIVATE LIMITED'
+
+  - value: 0x0D66
+    name: 'Hendrickson USA , L.L.C'
+
+  - value: 0x0D65
+    name: 'Molnlycke Health Care AB'
+
+  - value: 0x0D64
+    name: 'Southco'
+
+  - value: 0x0D63
+    name: 'SKF France'
+
+  - value: 0x0D62
+    name: 'MEBSTER s.r.o.'
+
+  - value: 0x0D61
+    name: 'F.I.P. FORMATURA INIEZIONE POLIMERI - S.P.A.'
+
+  - value: 0x0D60
+    name: 'Smart Products Connection, S.A.'
+
+  - value: 0x0D5F
+    name: 'SiChuan Homme Intelligent Technology co.,Ltd.'
+
+  - value: 0x0D5E
+    name: 'Pella Corp'
+
+  - value: 0x0D5D
+    name: 'Stogger B.V.'
+
+  - value: 0x0D5C
+    name: 'Pison Technology, Inc.'
+
+  - value: 0x0D5B
+    name: 'Axis Communications AB'
+
+  - value: 0x0D5A
+    name: 'Gunnebo Aktiebolag'
+
+  - value: 0x0D59
+    name: 'HYUPSUNG MACHINERY ELECTRIC CO., LTD.'
+
+  - value: 0x0D58
+    name: 'ifm electronic gmbh'
+
+  - value: 0x0D57
+    name: 'Nanjing Xinxiangyuan Microelectronics Co., Ltd.'
+
+  - value: 0x0D56
+    name: 'Wellang.Co,.Ltd'
+
+  - value: 0x0D55
+    name: 'NO CLIMB PRODUCTS LTD'
+
+  - value: 0x0D54
+    name: 'ISEKI FRANCE S.A.S'
+
+  - value: 0x0D53
+    name: 'Luxottica Group S.p.A'
+
+  - value: 0x0D52
+    name: 'DIVAN TRADING CO., LTD.'
+
+  - value: 0x0D51
+    name: 'Genetus inc.'
+
+  - value: 0x0D50
+    name: 'NINGBO FOTILE KITCHENWARE CO., LTD.'
+
+  - value: 0x0D4F
+    name: 'Movano Inc.'
+
+  - value: 0x0D4E
+    name: 'NIKAT SOLUTIONS PRIVATE LIMITED'
+
+  - value: 0x0D4D
+    name: 'Optec, LLC'
+
+  - value: 0x0D4C
+    name: 'IotGizmo Corporation'
+
+  - value: 0x0D4B
+    name: 'Soundwave Hearing, LLC'
+
+  - value: 0x0D4A
+    name: 'Rockpile Solutions, LLC'
+
+  - value: 0x0D49
+    name: 'Refrigerated Transport Electronics, Inc.'
+
+  - value: 0x0D48
+    name: 'Vemcon GmbH'
+
+  - value: 0x0D47
+    name: 'Shenzhen DOKE Electronic Co., Ltd'
+
+  - value: 0x0D46
+    name: 'Thales Simulation & Training AG'
+
+  - value: 0x0D45
+    name: 'Odeon, Inc.'
+
+  - value: 0x0D44
+    name: 'Ex Makhina Inc.'
+
+  - value: 0x0D43
+    name: 'Gosuncn Technology Group Co., Ltd.'
+
+  - value: 0x0D42
+    name: 'TEKTRO TECHNOLOGY CORPORATION'
+
+  - value: 0x0D41
+    name: 'CPAC Systems AB'
+
+  - value: 0x0D40
+    name: 'SignalFire Telemetry, Inc.'
+
+  - value: 0x0D3F
+    name: 'Vogels Products B.V.'
+
+  - value: 0x0D3E
+    name: 'LUMINOAH, INC.'
+
+  - value: 0x0D3D
+    name: 'bHaptics Inc.'
+
+  - value: 0x0D3C
+    name: 'SIRONA Dental Systems GmbH'
+
+  - value: 0x0D3B
+    name: 'Lone Star Marine Pty Ltd'
+
+  - value: 0x0D3A
+    name: 'Frost Solutions, LLC'
+
+  - value: 0x0D39
+    name: 'Systemic Games, LLC'
+
+  - value: 0x0D38
+    name: 'CycLock'
+
+  - value: 0x0D37
+    name: 'Zerene Inc.'
+
+  - value: 0x0D36
+    name: 'XIHAO INTELLIGENGT TECHNOLOGY CO., LTD'
+
+  - value: 0x0D35
+    name: 'Universidad Politecnica de Madrid'
+
+  - value: 0x0D34
+    name: 'ZILLIOT TECHNOLOGIES PRIVATE LIMITED'
+
+  - value: 0x0D33
+    name: 'Micropower Group AB'
+
+  - value: 0x0D32
+    name: 'Badger Meter'
+
+  - value: 0x0D31
+    name: 'SYNCHRON, INC.'
+
+  - value: 0x0D30
+    name: 'Laxmi Therapeutic Devices, Inc.'
+
+  - value: 0x0D2F
+    name: 'Delta Development Team, Inc'
+
+  - value: 0x0D2E
+    name: 'Advanced Electronic Applications, Inc'
+
+  - value: 0x0D2D
+    name: 'Cooler Pro, LLC'
+
+  - value: 0x0D2C
+    name: 'SIL System Integration Laboratory GmbH'
+
+  - value: 0x0D2B
+    name: 'Sensoryx AG'
+
+  - value: 0x0D2A
+    name: 'PhysioLogic Devices, Inc.'
+
+  - value: 0x0D29
+    name: 'MIYAKAWA ELECTRIC WORKS LTD.'
+
+  - value: 0x0D28
+    name: 'FUJITSU COMPONENT LIMITED'
+
+  - value: 0x0D27
+    name: 'velocitux'
+
+  - value: 0x0D26
+    name: 'Burkert Werke GmbH & Co. KG'
+
+  - value: 0x0D25
+    name: 'System Elite Holdings Group Limited'
+
+  - value: 0x0D24
+    name: 'Japan Display Inc.'
+
+  - value: 0x0D23
+    name: 'GREE Electric Appliances, Inc. of Zhuhai'
+
+  - value: 0x0D22
+    name: 'Cedarware, Corp.'
+
+  - value: 0x0D21
+    name: 'Cennox Group Limited'
+
+  - value: 0x0D20
+    name: 'SCIENTERRA LIMITED'
+
+  - value: 0x0D1F
+    name: 'Synkopi, Inc.'
+
+  - value: 0x0D1E
+    name: 'FESTINA LOTUS SA'
+
+  - value: 0x0D1D
+    name: 'Electronics4All Inc.'
+
+  - value: 0x0D1C
+    name: 'LIMBOID LLC'
+
+  - value: 0x0D1B
+    name: 'RACHIO, INC.'
+
+  - value: 0x0D1A
+    name: 'Maturix ApS'
+
+  - value: 0x0D19
+    name: 'C.G. Air Systemes Inc.'
+
+  - value: 0x0D18
+    name: 'Bioliberty Ltd'
+
+  - value: 0x0D17
+    name: 'Akix S.r.l.'
+
+  - value: 0x0D16
+    name: 'Nations Technologies Inc.'
+
+  - value: 0x0D15
+    name: 'Spark'
+
+  - value: 0x0D14
+    name: 'Merry Electronics (S) Pte Ltd'
+
+  - value: 0x0D13
+    name: 'MERRY ELECTRONICS CO., LTD.'
+
+  - value: 0x0D12
+    name: 'Spartek Systems Inc.'
+
+  - value: 0x0D11
+    name: 'Great Dane LLC'
+
+  - value: 0x0D10
+    name: 'JVC KENWOOD Corporation'
+
+  - value: 0x0D0F
+    name: 'Timebirds Australia Pty Ltd'
+
+  - value: 0x0D0E
+    name: 'PetVoice Co., Ltd.'
+
+  - value: 0x0D0D
+    name: 'C.Ed. Schulte GmbH Zylinderschlossfabrik'
+
+  - value: 0x0D0C
+    name: 'Planmeca Oy'
+
+  - value: 0x0D0B
+    name: 'Research Products Corporation'
+
+  - value: 0x0D0A
+    name: 'CATEYE Co., Ltd.'
+
+  - value: 0x0D09
+    name: 'Leica Geosystems AG'
+
+  - value: 0x0D08
+    name: 'Datalogic USA, Inc.'
+
+  - value: 0x0D07
+    name: 'Datalogic S.r.l.'
+
+  - value: 0x0D06
+    name: 'doubleO Co., Ltd.'
+
+  - value: 0x0D05
+    name: 'Energy Technology and Control Limited'
+
+  - value: 0x0D04
+    name: 'Bartec Auto Id Ltd'
+
+  - value: 0x0D03
+    name: 'MakuSafe Corp'
+
+  - value: 0x0D02
+    name: 'Rocky Mountain ATV/MC Jake Wilson'
+
+  - value: 0x0D01
+    name: 'KEEPEN'
+
+  - value: 0x0D00
+    name: 'Sparkpark AS'
+
+  - value: 0x0CFF
+    name: 'Ergodriven Inc'
+
+  - value: 0x0CFE
+    name: 'Thule Group AB'
+
+  - value: 0x0CFD
+    name: 'Wuhan Woncan Construction Technologies Co., Ltd.'
+
+  - value: 0x0CFC
+    name: 'ElectronX design'
+
+  - value: 0x0CFB
+    name: 'Tyromotion GmbH'
+
+  - value: 0x0CFA
+    name: 'Protect Animals With Satellites LLC'
+
+  - value: 0x0CF9
+    name: 'Tamblue Oy'
+
+  - value: 0x0CF8
+    name: 'core sensing GmbH'
+
+  - value: 0x0CF7
+    name: 'TVS Motor Company Ltd.'
+
+  - value: 0x0CF6
+    name: 'OJ Electronics A/S'
+
+  - value: 0x0CF5
+    name: 'BOS Balance of Storage Systems AG'
+
+  - value: 0x0CF4
+    name: 'SOLUX PTY LTD'
+
+  - value: 0x0CF3
+    name: 'Radio Sound'
+
+  - value: 0x0CF2
+    name: 'BestSens AG'
+
+  - value: 0x0CF1
+    name: 'Midmark'
+
+  - value: 0x0CF0
+    name: 'THOTAKA TEKHNOLOGIES INDIA PRIVATE LIMITED'
+
+  - value: 0x0CEF
+    name: 'POGS B.V.'
+
+  - value: 0x0CEE
+    name: 'MadgeTech, Inc'
+
+  - value: 0x0CED
+    name: 'CV. NURI TEKNIK'
+
+  - value: 0x0CEC
+    name: 'Pacific Coast Fishery Services (2003) Inc.'
+
+  - value: 0x0CEB
+    name: 'Shenzhen Tingting Technology Co. LTD'
+
+  - value: 0x0CEA
+    name: 'HAYWARD INDUSTRIES, INC.'
+
+  - value: 0x0CE9
+    name: 'PEAG, LLC dba JLab Audio'
+
+  - value: 0x0CE8
+    name: 'Dongguan Yougo Electronics Co.,Ltd.'
+
+  - value: 0x0CE7
+    name: 'TAG HEUER SA'
+
+  - value: 0x0CE6
+    name: 'McWong International, Inc.'
+
+  - value: 0x0CE5
+    name: 'Amina Distribution AS'
+
+  - value: 0x0CE4
+    name: 'Off-Highway Powertrain Services Germany GmbH'
+
+  - value: 0x0CE3
+    name: 'Taiwan Fuhsing'
+
+  - value: 0x0CE2
+    name: 'CORVENT MEDICAL, INC.'
+
+  - value: 0x0CE1
+    name: 'Regal Beloit America, Inc.'
+
+  - value: 0x0CE0
+    name: 'VODALOGIC PTY LTD'
+
+  - value: 0x0CDF
+    name: 'SHENZHEN CHENYUN ELECTRONICS  CO., LTD'
+
+  - value: 0x0CDE
+    name: 'RESPONSE TECHNOLOGIES, LTD.'
+
+  - value: 0x0CDD
+    name: 'Alif Semiconductor, Inc.'
+
+  - value: 0x0CDC
+    name: 'Ypsomed AG'
+
+  - value: 0x0CDB
+    name: 'Circus World Displays Limited'
+
+  - value: 0x0CDA
+    name: 'Wolf Steel ltd'
+
+  - value: 0x0CD9
+    name: 'Minami acoustics Limited'
+
+  - value: 0x0CD8
+    name: 'SIA Mesh Group'
+
+  - value: 0x0CD7
+    name: 'Maztech Industries, LLC'
+
+  - value: 0x0CD6
+    name: 'HHO (Hangzhou) Digital Technology Co., Ltd.'
+
+  - value: 0x0CD5
+    name: 'Numa Products, LLC'
+
+  - value: 0x0CD4
+    name: 'Reoqoo IoT Technology Co., Ltd.'
+
+  - value: 0x0CD3
+    name: 'TechSwipe'
+
+  - value: 0x0CD2
+    name: 'EQOM SSC B.V.'
+
+  - value: 0x0CD1
+    name: 'Imagine Marketing Limited'
+
+  - value: 0x0CD0
+    name: 'MooreSilicon Semiconductor Technology (Shanghai) Co., LTD.'
+
+  - value: 0x0CCF
+    name: 'Shenzhen CESI Information Technology Co., Ltd.'
+
+  - value: 0x0CCE
+    name: 'SENOSPACE LLC'
+
+  - value: 0x0CCD
+    name: 'YanFeng Visteon(Chongqing) Automotive Electronic Co.,Ltd'
+
+  - value: 0x0CCC
+    name: 'Kord Defence Pty Ltd'
+
+  - value: 0x0CCB
+    name: 'NOTHING TECHNOLOGY LIMITED'
+
+  - value: 0x0CCA
+    name: 'Cyclops Marine Ltd'
+
+  - value: 0x0CC9
+    name: 'Innocent Technology Co., Ltd.'
+
+  - value: 0x0CC8
+    name: 'TrikThom'
+
+  - value: 0x0CC7
+    name: 'SB C&S Corp.'
+
+  - value: 0x0CC6
+    name: 'Serial Technology Corporation'
+
+  - value: 0x0CC5
+    name: 'Open Road Solutions, Inc.'
+
+  - value: 0x0CC4
+    name: 'ABUS August Bremicker Soehne Kommanditgesellschaft'
+
+  - value: 0x0CC3
+    name: 'HMD Global Oy'
+
+  - value: 0x0CC2
+    name: 'Anker Innovations Limited'
+
+  - value: 0x0CC1
+    name: 'CLEIO Inc.'
+
+  - value: 0x0CC0
+    name: 'Garnet Instruments Ltd.'
+
+  - value: 0x0CBF
+    name: 'Forward Thinking Systems LLC.'
+
+  - value: 0x0CBD
+    name: 'Pricer AB'
+
+  - value: 0x0CBC
+    name: 'TROX GmbH'
+
+  - value: 0x0CBB
+    name: 'Emlid Tech Kft.'
+
+  - value: 0x0CBA
+    name: 'Ameso Tech (OPC) Private Limited'
+
+  - value: 0x0CB9
+    name: 'seca GmbH & Co. KG'
+
+  - value: 0x0CB8
+    name: 'Shanghai Proxy Network Technology Co., Ltd.'
+
+  - value: 0x0CB7
+    name: 'Cucumber Lighting Controls Limited'
+
+  - value: 0x0CB6
+    name: 'THE EELECTRIC MACARON LLC'
+
+  - value: 0x0CB5
+    name: 'Racketry, d. o. o.'
+
+  - value: 0x0CB4
+    name: 'Eberspaecher Climate Control Systems GmbH'
+
+  - value: 0x0CB3
+    name: 'janova GmbH'
+
+  - value: 0x0CB2
+    name: 'SHINKAWA Sensor Technology, Inc.'
+
+  - value: 0x0CB1
+    name: 'RF Creations'
+
+  - value: 0x0CB0
+    name: 'SwipeSense, Inc.'
+
+  - value: 0x0CAF
+    name: 'NEURINNOV'
+
+  - value: 0x0CAE
+    name: 'Evident Corporation'
+
+  - value: 0x0CAD
+    name: 'Shenzhen Openhearing Tech CO., LTD .'
+
+  - value: 0x0CAC
+    name: 'Shenzhen Shokz Co.,Ltd.'
+
+  - value: 0x0CAB
+    name: 'HERUTU ELECTRONICS CORPORATION'
+
+  - value: 0x0CAA
+    name: 'Shenzhen Poseidon Network Technology Co., Ltd'
+
+  - value: 0x0CA9
+    name: 'Mievo Technologies Private Limited'
+
+  - value: 0x0CA8
+    name: 'Sonas, Inc.'
+
+  - value: 0x0CA7
+    name: 'Verve InfoTec Pty Ltd'
+
+  - value: 0x0CA6
+    name: 'Megger Ltd'
+
+  - value: 0x0CA5
+    name: 'Princess Cruise Lines, Ltd.'
+
+  - value: 0x0CA4
+    name: 'MITSUBISHI ELECTRIC LIGHTING CO, LTD'
+
+  - value: 0x0CA3
+    name: 'MAQUET GmbH'
+
+  - value: 0x0CA2
+    name: 'XSENSE LTD'
+
+  - value: 0x0CA1
+    name: 'YAMAHA MOTOR CO.,LTD.'
+
+  - value: 0x0CA0
+    name: 'BIGBEN'
+
+  - value: 0x0C9F
+    name: 'Dragonfly Energy Corp.'
+
+  - value: 0x0C9E
+    name: 'ECCEL CORPORATION SAS'
+
+  - value: 0x0C9D
+    name: 'Ribbiot, INC.'
+
+  - value: 0x0C9C
+    name: 'Sunstone-RTLS Ipari Szolgaltato Korlatolt Felelossegu Tarsasag'
+
+  - value: 0x0C9B
+    name: 'NTT sonority, Inc.'
+
+  - value: 0x0C9A
+    name: 'ALF Inc.'
+
+  - value: 0x0C99
+    name: 'Vire Health Oy'
+
+  - value: 0x0C98
+    name: 'MiX Telematics International (PTY) LTD'
+
+  - value: 0x0C97
+    name: 'Deako'
+
+  - value: 0x0C96
+    name: 'H+B Hightech GmbH'
+
+  - value: 0x0C95
+    name: 'Gemstone Lights Canada Ltd.'
+
+  - value: 0x0C94
+    name: 'Baxter Healthcare Corporation'
+
+  - value: 0x0C93
+    name: 'Movesense Oy'
+
+  - value: 0x0C92
+    name: 'Kesseböhmer Ergonomietechnik GmbH'
+
+  - value: 0x0C91
+    name: 'Yashu Systems'
+
+  - value: 0x0C90
+    name: 'WESCO AG'
+
+  - value: 0x0C8F
+    name: 'Radar Automobile Sales(Shandong)Co.,Ltd.'
+
+  - value: 0x0C8E
+    name: 'Technocon Engineering Ltd.'
+
+  - value: 0x0C8D
+    name: 'tonies GmbH'
+
+  - value: 0x0C8C
+    name: 'T-Mobile USA'
+
+  - value: 0x0C8B
+    name: 'Heavys Inc'
+
+  - value: 0x0C8A
+    name: 'A.GLOBAL co.,Ltd.'
+
+  - value: 0x0C89
+    name: 'AGZZX OPTOELECTRONICS TECHNOLOGY CO., LTD'
+
+  - value: 0x0C88
+    name: 'Nextivity Inc.'
+
+  - value: 0x0C87
+    name: 'Weltek Technologies Company Limited'
+
+  - value: 0x0C86
+    name: 'Qingdao Eastsoft Communication Technology Co.,Ltd'
+
+  - value: 0x0C85
+    name: 'Amlogic, Inc.'
+
+  - value: 0x0C84
+    name: 'MAXON INDUSTRIES, INC.'
+
+  - value: 0x0C83
+    name: 'Watchdog Systems LLC'
+
+  - value: 0x0C82
+    name: 'NACON'
+
+  - value: 0x0C81
+    name: 'Carrier Corporation'
+
+  - value: 0x0C80
+    name: 'CARDIOID - TECHNOLOGIES, LDA'
+
+  - value: 0x0C7F
+    name: 'Rochester Sensors, LLC'
+
+  - value: 0x0C7E
+    name: 'BOOMING OF THINGS'
+
+  - value: 0x0C7D
+    name: '3ALogics, Inc.'
+
+  - value: 0x0C7C
+    name: 'Mopeka Products LLC'
+
+  - value: 0x0C7B
+    name: 'PT SADAMAYA GRAHA TEKNOLOGI'
+
+  - value: 0x0C7A
+    name: 'Triductor Technology (Suzhou), Inc.'
+
+  - value: 0x0C79
+    name: 'Zhuhai Smartlink Technology Co., Ltd'
+
+  - value: 0x0C78
+    name: 'CHARGTRON IOT PRIVATE LIMITED'
+
+  - value: 0x0C77
+    name: 'TEAC Corporation'
+
+  - value: 0x0C76
+    name: 'Shenzhen Gwell Times Technology Co. , Ltd'
+
+  - value: 0x0C75
+    name: 'Embedded Engineering Solutions LLC'
+
+  - value: 0x0C74
+    name: 'yupiteru'
+
+  - value: 0x0C73
+    name: 'Truma Gerätetechnik GmbH & Co. KG'
+
+  - value: 0x0C72
+    name: 'StreetCar ORV, LLC'
+
+  - value: 0x0C71
+    name: 'BitGreen Technolabz (OPC) Private Limited'
+
+  - value: 0x0C70
+    name: 'SCARAB SOLUTIONS LTD'
+
+  - value: 0x0C6F
+    name: 'Parakey AB'
+
+  - value: 0x0C6E
+    name: 'Sensa LLC'
+
+  - value: 0x0C6D
+    name: 'Fidure Corp.'
+
+  - value: 0x0C6C
+    name: 'SNIFF LOGIC LTD'
+
+  - value: 0x0C6B
+    name: 'GILSON SAS'
+
+  - value: 0x0C6A
+    name: 'CONSORCIO TRUST CONTROL - NETTEL'
+
+  - value: 0x0C69
+    name: 'BLITZ electric motors. LTD'
+
+  - value: 0x0C68
+    name: 'Emerja Corporation'
+
+  - value: 0x0C67
+    name: 'TRACKTING S.R.L.'
+
+  - value: 0x0C66
+    name: 'DEN Smart Home B.V.'
+
+  - value: 0x0C65
+    name: 'WAKO CO,.LTD'
+
+  - value: 0x0C64
+    name: 'dormakaba Holding AG'
+
+  - value: 0x0C63
+    name: 'phg Peter Hengstler GmbH + Co. KG'
+
+  - value: 0x0C62
+    name: 'Phiaton Corporation'
+
+  - value: 0x0C61
+    name: 'NNOXX, Inc'
+
+  - value: 0x0C60
+    name: 'KEBA Energy Automation GmbH'
+
+  - value: 0x0C5F
+    name: 'Wuxi Linkpower Microelectronics Co.,Ltd'
+
+  - value: 0x0C5E
+    name: 'BlueID GmbH'
+
+  - value: 0x0C5D
+    name: 'StepUp Solutions ApS'
+
+  - value: 0x0C5C
+    name: 'MGM WIRELESSS HOLDINGS PTY LTD'
+
+  - value: 0x0C5B
+    name: 'Alban Giacomo S.P.A.'
+
+  - value: 0x0C5A
+    name: 'Lockswitch Sdn Bhd'
+
+  - value: 0x0C59
+    name: 'CYBERDYNE Inc.'
+
+  - value: 0x0C58
+    name: 'Hykso Inc.'
+
+  - value: 0x0C57
+    name: 'UNEEG medical A/S'
+
+  - value: 0x0C56
+    name: 'Rheem Sales Company, Inc.'
+
+  - value: 0x0C55
+    name: 'Zintouch B.V.'
+
+  - value: 0x0C54
+    name: 'HiViz Lighting, Inc.'
+
+  - value: 0x0C53
+    name: 'Taco, Inc.'
+
+  - value: 0x0C52
+    name: 'ESCEA LIMITED'
+
+  - value: 0x0C51
+    name: 'INNOVA S.R.L.'
+
+  - value: 0x0C50
+    name: 'Imostar Technologies Inc.'
+
+  - value: 0x0C4F
+    name: 'SharkNinja Operating LLC'
+
+  - value: 0x0C4E
+    name: 'Tactile Engineering, Inc.'
+
+  - value: 0x0C4D
+    name: 'Seekwave Technology Co.,ltd.'
+
+  - value: 0x0C4C
+    name: 'Orpyx Medical Technologies Inc.'
+
+  - value: 0x0C4B
+    name: 'ADTRAN, Inc.'
+
+  - value: 0x0C4A
+    name: 'atSpiro ApS'
+
+  - value: 0x0C49
+    name: 'twopounds gmbh'
+
+  - value: 0x0C48
+    name: 'VALEO MANAGEMENT SERVICES'
+
+  - value: 0x0C47
+    name: 'Epsilon Electronics,lnc'
+
+  - value: 0x0C46
+    name: 'Granwin IoT Technology (Guangzhou) Co.,Ltd'
+
+  - value: 0x0C45
+    name: 'Brose Verwaltung SE, Bamberg'
+
+  - value: 0x0C44
+    name: 'ONCELABS LLC'
+
+  - value: 0x0C43
+    name: 'Berlinger & Co. AG'
+
+  - value: 0x0C42
+    name: 'Heath Consultants Inc.'
+
+  - value: 0x0C41
+    name: 'Control Solutions LLC'
+
+  - value: 0x0C40
+    name: 'HORIBA, Ltd.'
+
+  - value: 0x0C3F
+    name: 'Stinger Equipment, Inc.'
+
+  - value: 0x0C3E
+    name: 'BELLDESIGN Inc.'
+
+  - value: 0x0C3D
+    name: 'Wrmth Corp.'
+
+  - value: 0x0C3C
+    name: 'Classified Cycling'
+
+  - value: 0x0C3B
+    name: 'ORB Innovations Ltd'
+
+  - value: 0x0C3A
+    name: 'Equinosis, LLC'
+
+  - value: 0x0C39
+    name: 'TIGER CORPORATION'
+
+  - value: 0x0C38
+    name: 'Noritz Corporation.'
+
+  - value: 0x0C37
+    name: 'SignalQuest, LLC'
+
+  - value: 0x0C36
+    name: 'Cosmicnode BV'
+
+  - value: 0x0C35
+    name: 'Thermokon-Sensortechnik GmbH'
+
+  - value: 0x0C34
+    name: 'BYD Company Limited'
+
+  - value: 0x0C33
+    name: 'Exeger Operations AB'
+
+  - value: 0x0C32
+    name: 'Xian Yisuobao Electronic Technology Co., Ltd.'
+
+  - value: 0x0C31
+    name: 'KINDOO LLP'
+
+  - value: 0x0C30
+    name: 'McIntosh Group Inc'
+
+  - value: 0x0C2F
+    name: 'BEEHERO, INC.'
+
+  - value: 0x0C2E
+    name: 'Easee AS'
+
+  - value: 0x0C2D
+    name: 'OTF Product Sourcing, LLC'
+
+  - value: 0x0C2C
+    name: 'Zeku Technology (Shanghai) Corp., Ltd.'
+
+  - value: 0x0C2B
+    name: 'GigaDevice Semiconductor Inc.'
+
+  - value: 0x0C2A
+    name: 'Caresix Inc.'
+
+  - value: 0x0C29
+    name: 'DENSO AIRCOOL CORPORATION'
+
+  - value: 0x0C28
+    name: 'Embecta Corp.'
+
+  - value: 0x0C27
+    name: 'Pal Electronics'
+
+  - value: 0x0C26
+    name: 'Performance Electronics, Ltd.'
+
+  - value: 0x0C25
+    name: 'JURA Elektroapparate AG'
+
+  - value: 0x0C24
+    name: 'SMARTD TECHNOLOGIES INC.'
+
+  - value: 0x0C23
+    name: 'KEYTEC,Inc.'
+
+  - value: 0x0C22
+    name: 'Glamo Inc.'
+
+  - value: 0x0C21
+    name: 'Foshan Viomi Electrical Technology Co., Ltd'
+
+  - value: 0x0C20
+    name: 'COMELIT GROUP S.P.A.'
+
+  - value: 0x0C1F
+    name: 'LVI Co.'
+
+  - value: 0x0C1E
+    name: 'EC sense co., Ltd'
+
+  - value: 0x0C1D
+    name: 'OFF Line Japan Co., Ltd.'
+
+  - value: 0x0C1C
+    name: 'GEMU'
+
+  - value: 0x0C1B
+    name: 'Rockchip Electronics Co., Ltd.'
+
+  - value: 0x0C1A
+    name: 'Catapult Group International Ltd'
+
+  - value: 0x0C19
+    name: 'Arlo Technologies, Inc.'
+
+  - value: 0x0C18
+    name: 'CORROHM'
+
+  - value: 0x0C17
+    name: 'SomnoMed Limited'
+
+  - value: 0x0C16
+    name: 'TYKEE PTY. LTD.'
+
+  - value: 0x0C15
+    name: 'Geva Sol B.V.'
+
+  - value: 0x0C14
+    name: 'Fasetto, Inc.'
+
+  - value: 0x0C13
+    name: 'Scandinavian Health Limited'
+
+  - value: 0x0C12
+    name: 'IoSA'
+
+  - value: 0x0C11
+    name: 'Gordon Murray Design Limited'
+
+  - value: 0x0C10
+    name: 'Cosmed s.r.l.'
+
+  - value: 0x0C0F
+    name: 'AETERLINK'
+
+  - value: 0x0C0E
+    name: 'ALEX DENKO CO.,LTD.'
+
+  - value: 0x0C0D
+    name: 'Mereltron bv'
+
+  - value: 0x0C0C
+    name: 'Mendeltron, Inc.'
+
+  - value: 0x0C0B
+    name: 'aconno GmbH'
+
+  - value: 0x0C0A
+    name: 'Automated Pet Care Products, LLC'
+
+  - value: 0x0C09
+    name: 'Senic Inc.'
+
+  - value: 0x0C08
+    name: 'limited liability company "Red"'
+
+  - value: 0x0C07
+    name: 'CONSTRUKTS, INC.'
+
+  - value: 0x0C06
+    name: 'LED Smart Inc.'
+
+  - value: 0x0C05
+    name: 'Montage Connect, Inc.'
+
+  - value: 0x0C04
+    name: 'Happy Health, Inc.'
+
+  - value: 0x0C03
+    name: 'Puff Corp'
+
+  - value: 0x0C02
+    name: 'Loomanet, Inc.'
+
+  - value: 0x0C01
+    name: 'NEOWRK SISTEMAS INTELIGENTES S.A.'
+
+  - value: 0x0C00
+    name: 'MQA Limited'
+
+  - value: 0x0BFF
+    name: 'Ratio Electric BV'
+
+  - value: 0x0BFE
+    name: 'Media-Cartec GmbH'
+
+  - value: 0x0BFD
+    name: 'Esmé Solutions'
+
+  - value: 0x0BFC
+    name: 'T+A elektroakustik GmbH & Co.KG'
+
+  - value: 0x0BFB
+    name: 'Dodam Enersys Co., Ltd'
+
+  - value: 0x0BFA
+    name: 'CleanBands Systems Ltd.'
+
+  - value: 0x0BF9
+    name: 'Alio, Inc'
+
+  - value: 0x0BF8
+    name: 'Innovacionnye Resheniya'
+
+  - value: 0x0BF7
+    name: 'Wacker Neuson SE'
+
+  - value: 0x0BF6
+    name: 'greenTEG AG'
+
+  - value: 0x0BF5
+    name: 'T5 tek, Inc.'
+
+  - value: 0x0BF4
+    name: 'ER Lab LLC'
+
+  - value: 0x0BF3
+    name: 'PONE BIOMETRICS AS'
+
+  - value: 0x0BF2
+    name: 'Angel Medical Systems, Inc.'
+
+  - value: 0x0BF1
+    name: 'Site IQ LLC'
+
+  - value: 0x0BF0
+    name: 'KIDO SPORTS CO., LTD.'
+
+  - value: 0x0BEF
+    name: 'Safetytest GmbH'
+
+  - value: 0x0BEE
+    name: 'LINKSYS USA, INC.'
+
+  - value: 0x0BED
+    name: 'CORAL-TAIYI Co. Ltd.'
+
+  - value: 0x0BEC
+    name: 'Miracle-Ear, Inc.'
+
+  - value: 0x0BEB
+    name: 'Luna Health, Inc.'
+
+  - value: 0x0BEA
+    name: 'Twenty Five Seven, prodaja in storitve, d.o.o.'
+
+  - value: 0x0BE9
+    name: 'Shindengen Electric Manufacturing Co., Ltd.'
+
+  - value: 0x0BE8
+    name: 'Sensormate AG'
+
+  - value: 0x0BE7
+    name: 'Fresnel Technologies, Inc.'
+
+  - value: 0x0BE6
+    name: 'Puratap Pty Ltd'
+
+  - value: 0x0BE5
+    name: 'ZWILLING J.A. Henckels Aktiengesellschaft'
+
+  - value: 0x0BE4
+    name: 'Deepfield Connect GmbH'
+
+  - value: 0x0BE3
+    name: 'Comtel Systems Ltd.'
+
+  - value: 0x0BE2
+    name: 'OTC engineering'
+
+  - value: 0x0BE1
+    name: 'Back40 Precision'
+
+  - value: 0x0BE0
+    name: 'Koizumi Lighting Technology corp.'
+
+  - value: 0x0BDF
+    name: 'WINKEY ENTERPRISE (HONG KONG) LIMITED'
+
+  - value: 0x0BDE
+    name: 'Yale'
+
+  - value: 0x0BDD
+    name: 'Coroflo Limited'
+
+  - value: 0x0BDC
+    name: 'Ledworks S.r.l.'
+
+  - value: 0x0BDB
+    name: 'CHAR-BROIL, LLC'
+
+  - value: 0x0BDA
+    name: 'Aardex Ltd.'
+
+  - value: 0x0BD9
+    name: 'Elics Basis Ltd.'
+
+  - value: 0x0BD8
+    name: 'PURA SCENTS, INC.'
+
+  - value: 0x0BD7
+    name: 'VINFAST TRADING AND PRODUCTION JOINT STOCK COMPANY'
+
+  - value: 0x0BD6
+    name: 'Shenzhen Injoinic Technology Co., Ltd.'
+
+  - value: 0x0BD5
+    name: 'Super B Lithium Power B.V.'
+
+  - value: 0x0BD4
+    name: 'ndd Medizintechnik AG'
+
+  - value: 0x0BD3
+    name: 'Procon Analytics, LLC'
+
+  - value: 0x0BD2
+    name: 'IDEC'
+
+  - value: 0x0BD1
+    name: 'Hubei Yuan Times Technology Co., Ltd.'
+
+  - value: 0x0BD0
+    name: 'Durag GmbH'
+
+  - value: 0x0BCF
+    name: 'LL Tec Group LLC'
+
+  - value: 0x0BCE
+    name: 'Neurosity, Inc.'
+
+  - value: 0x0BCD
+    name: 'Amiko srl'
+
+  - value: 0x0BCC
+    name: 'Sylvac sa'
+
+  - value: 0x0BCB
+    name: 'Divesoft s.r.o.'
+
+  - value: 0x0BCA
+    name: 'Perimeter Technologies, Inc.'
+
+  - value: 0x0BC9
+    name: 'Neuvatek Inc.'
+
+  - value: 0x0BC8
+    name: 'OTF Distribution, LLC'
+
+  - value: 0x0BC7
+    name: 'Signtle Inc.'
+
+  - value: 0x0BC6
+    name: 'TCL COMMUNICATION EQUIPMENT CO.,LTD.'
+
+  - value: 0x0BC5
+    name: 'Aperia Technologies, Inc.'
+
+  - value: 0x0BC4
+    name: 'TECHTICS ENGINEERING B.V.'
+
+  - value: 0x0BC3
+    name: 'MCOT INC.'
+
+  - value: 0x0BC2
+    name: 'EntWick Co.'
+
+  - value: 0x0BC1
+    name: 'Miele & Cie. KG'
+
+  - value: 0x0BC0
+    name: 'READY FOR SKY LLP'
+
+  - value: 0x0BBF
+    name: 'HIMSA II K/S'
+
+  - value: 0x0BBE
+    name: 'SAAB Aktiebolag'
+
+  - value: 0x0BBD
+    name: 'ETHEORY PTY LTD'
+
+  - value: 0x0BBC
+    name: 'T2REALITY SOLUTIONS PRIVATE LIMITED'
+
+  - value: 0x0BBB
+    name: 'SWISSINNO SOLUTIONS AG'
+
+  - value: 0x0BBA
+    name: 'Huso, INC'
+
+  - value: 0x0BB9
+    name: 'SaluStim Group Oy'
+
+  - value: 0x0BB8
+    name: 'INNOVAG PTY. LTD.'
+
+  - value: 0x0BB7
+    name: 'IONA Tech LLC'
+
+  - value: 0x0BB6
+    name: 'Build With Robots Inc.'
+
+  - value: 0x0BB5
+    name: 'Xirgo Technologies, LLC'
+
+  - value: 0x0BB4
+    name: 'New Cosmos USA, Inc.'
+
+  - value: 0x0BB3
+    name: 'Flender GmbH'
+
+  - value: 0x0BB2
+    name: 'Fjorden Electra AS'
+
+  - value: 0x0BB1
+    name: 'Beijing ranxin intelligence technology Co.,LTD'
+
+  - value: 0x0BB0
+    name: 'Ecolab Inc.'
+
+  - value: 0x0BAF
+    name: 'NITTO KOGYO CORPORATION'
+
+  - value: 0x0BAE
+    name: 'Soma Labs LLC'
+
+  - value: 0x0BAD
+    name: 'Roambotics, Inc.'
+
+  - value: 0x0BAC
+    name: 'Machfu Inc.'
+
+  - value: 0x0BAB
+    name: 'Grandex International Corporation'
+
+  - value: 0x0BAA
+    name: 'Infinitegra, Inc.'
+
+  - value: 0x0BA9
+    name: 'Allterco Robotics ltd'
+
+  - value: 0x0BA8
+    name: 'GLOWFORGE INC.'
+
+  - value: 0x0BA7
+    name: 'hearX Group (Pty) Ltd'
+
+  - value: 0x0BA6
+    name: 'Nissan Motor Co., Ltd.'
+
+  - value: 0x0BA5
+    name: 'SONICOS ENTERPRISES, LLC'
+
+  - value: 0x0BA4
+    name: 'Vervent Audio Group'
+
+  - value: 0x0BA3
+    name: 'Sonova Consumer Hearing GmbH'
+
+  - value: 0x0BA2
+    name: 'TireCheck GmbH'
+
+  - value: 0x0BA1
+    name: 'Bunn-O-Matic Corporation'
+
+  - value: 0x0BA0
+    name: 'Data Sciences International'
+
+  - value: 0x0B9F
+    name: 'Group Lotus Limited'
+
+  - value: 0x0B9E
+    name: 'Audio Partnership Plc'
+
+  - value: 0x0B9D
+    name: 'Sensoria Holdings LTD'
+
+  - value: 0x0B9C
+    name: 'Komatsu Ltd.'
+
+  - value: 0x0B9B
+    name: 'GISMAN'
+
+  - value: 0x0B9A
+    name: 'Beijing Wisepool Infinite Intelligence Technology Co.,Ltd'
+
+  - value: 0x0B99
+    name: 'The Goodyear Tire & Rubber Company'
+
+  - value: 0x0B98
+    name: 'Gymstory B.V.'
+
+  - value: 0x0B97
+    name: 'SILVER TREE LABS, INC.'
+
+  - value: 0x0B96
+    name: 'Telecom Design'
+
+  - value: 0x0B95
+    name: 'Netwake GmbH'
+
+  - value: 0x0B94
+    name: 'Dreem SAS'
+
+  - value: 0x0B93
+    name: 'Hangzhou BroadLink Technology Co., Ltd.'
+
+  - value: 0x0B92
+    name: 'Citisend Solutions, SL'
+
+  - value: 0x0B91
+    name: 'Alfen ICU B.V.'
+
+  - value: 0x0B90
+    name: 'Ineos Automotive Limited'
+
+  - value: 0x0B8F
+    name: 'Senscomm Semiconductor Co., Ltd.'
+
+  - value: 0x0B8E
+    name: 'Gentle Energy Corp.'
+
+  - value: 0x0B8D
+    name: 'Pertech Industries Inc'
+
+  - value: 0x0B8C
+    name: 'MOTREX'
+
+  - value: 0x0B8B
+    name: 'American Technology Components, Incorporated'
+
+  - value: 0x0B8A
+    name: 'Seiko Instruments Inc.'
+
+  - value: 0x0B89
+    name: 'Rotronic AG'
+
+  - value: 0x0B88
+    name: 'Muguang (Guangdong) Intelligent Lighting Technology Co., Ltd'
+
+  - value: 0x0B87
+    name: 'Ampetronic Ltd'
+
+  - value: 0x0B86
+    name: 'Trek Bicycle'
+
+  - value: 0x0B85
+    name: 'VIMANA TECH PTY LTD'
+
+  - value: 0x0B84
+    name: 'Presidio Medical, Inc.'
+
+  - value: 0x0B83
+    name: 'Taiga Motors Inc.'
+
+  - value: 0x0B82
+    name: 'Mammut Sports Group AG'
+
+  - value: 0x0B81
+    name: 'SCM Group'
+
+  - value: 0x0B80
+    name: 'AXELIFE'
+
+  - value: 0x0B7F
+    name: 'ICU tech GmbH'
+
+  - value: 0x0B7E
+    name: 'Offcode Oy'
+
+  - value: 0x0B7D
+    name: 'FoundersLane GmbH'
+
+  - value: 0x0B7C
+    name: 'Scangrip A/S'
+
+  - value: 0x0B7B
+    name: 'Hardcoder Oy'
+
+  - value: 0x0B7A
+    name: 'Shenzhen KTC Technology Co.,Ltd.'
+
+  - value: 0x0B79
+    name: 'Sankyo Air Tech Co.,Ltd.'
+
+  - value: 0x0B78
+    name: 'FIELD DESIGN INC.'
+
+  - value: 0x0B77
+    name: 'Aixlink(Chengdu) Co., Ltd.'
+
+  - value: 0x0B76
+    name: 'MAX-co., ltd'
+
+  - value: 0x0B75
+    name: 'Triple W Japan Inc.'
+
+  - value: 0x0B74
+    name: 'BQN'
+
+  - value: 0x0B73
+    name: 'HARADA INDUSTRY CO., LTD.'
+
+  - value: 0x0B72
+    name: 'Geeknet, Inc.'
+
+  - value: 0x0B71
+    name: 'lilbit ODM AS'
+
+  - value: 0x0B70
+    name: 'JDRF Electromag Engineering Inc'
+
+  - value: 0x0B6F
+    name: 'Shenzhen Malide Technology Co.,Ltd'
+
+  - value: 0x0B6E
+    name: 'React Mobile'
+
+  - value: 0x0B6D
+    name: 'SOLUM CO., LTD'
+
+  - value: 0x0B6C
+    name: 'Sensitech, Inc.'
+
+  - value: 0x0B6B
+    name: 'Samsara Networks, Inc'
+
+  - value: 0x0B6A
+    name: 'Dymo'
+
+  - value: 0x0B69
+    name: 'Addaday'
+
+  - value: 0x0B68
+    name: 'Quha oy'
+
+  - value: 0x0B67
+    name: 'CleanSpace Technology Pty Ltd'
+
+  - value: 0x0B66
+    name: 'MITSUBISHI ELECTRIC AUTOMATION (THAILAND) COMPANY LIMITED'
+
+  - value: 0x0B65
+    name: 'The Apache Software Foundation'
+
+  - value: 0x0B64
+    name: 'NingBo klite Electric Manufacture Co.,LTD'
+
+  - value: 0x0B63
+    name: 'Innolux Corporation'
+
+  - value: 0x0B62
+    name: 'NOVEA ENERGIES'
+
+  - value: 0x0B61
+    name: 'Sentek Pty Ltd'
+
+  - value: 0x0B60
+    name: 'RATOC Systems, Inc.'
+
+  - value: 0x0B5F
+    name: 'Rivieh, Inc.'
+
+  - value: 0x0B5E
+    name: 'CELLCONTROL, INC.'
+
+  - value: 0x0B5D
+    name: 'Fujian Newland Auto-ID Tech. Co., Ltd.'
+
+  - value: 0x0B5C
+    name: 'Exponential Power, Inc.'
+
+  - value: 0x0B5B
+    name: 'Shenzhen ImagineVision Technology Limited'
+
+  - value: 0x0B5A
+    name: 'H.P. Shelby Manufacturing, LLC.'
+
+  - value: 0x0B59
+    name: 'Versa Group B.V.'
+
+  - value: 0x0B58
+    name: 'TOKAI-DENSHI INC'
+
+  - value: 0x0B57
+    name: 'CONVERTRONIX TECHNOLOGIES AND SERVICES LLP'
+
+  - value: 0x0B56
+    name: 'BORA - Vertriebs GmbH & Co KG'
+
+  - value: 0x0B55
+    name: 'H G M Automotive Electronics, Inc.'
+
+  - value: 0x0B54
+    name: 'Emotion Fitness GmbH & Co. KG'
+
+  - value: 0x0B53
+    name: 'SHENZHEN KAADAS INTELLIGENT TECHNOLOGY CO.,Ltd'
+
+  - value: 0x0B52
+    name: 'ZIIP Inc'
+
+  - value: 0x0B51
+    name: 'FUN FACTORY GmbH'
+
+  - value: 0x0B50
+    name: 'Mesh Systems LLC'
+
+  - value: 0x0B4F
+    name: 'Breezi.io, Inc.'
+
+  - value: 0x0B4E
+    name: 'ICP Systems B.V.'
+
+  - value: 0x0B4D
+    name: 'Adam Hall GmbH'
+
+  - value: 0x0B4C
+    name: 'BiosBob.Biz'
+
+  - value: 0x0B4B
+    name: 'EMS Integrators, LLC'
+
+  - value: 0x0B4A
+    name: 'Nomono AS'
+
+  - value: 0x0B49
+    name: 'SkyHawke Technologies'
+
+  - value: 0x0B48
+    name: 'NIO USA, Inc.'
+
+  - value: 0x0B47
+    name: 'Gentex Corporation'
+
+  - value: 0x0B46
+    name: 'Bird Rides, Inc.'
+
+  - value: 0x0B45
+    name: 'Electronic Sensors, Inc.'
+
+  - value: 0x0B44
+    name: 'nFore Technology Co., Ltd.'
+
+  - value: 0x0B43
+    name: 'INCITAT ENVIRONNEMENT'
+
+  - value: 0x0B42
+    name: 'TSI'
+
+  - value: 0x0B41
+    name: 'Sentrax GmbH'
+
+  - value: 0x0B40
+    name: 'Havells India Limited'
+
+  - value: 0x0B3F
+    name: 'MindRhythm, Inc.'
+
+  - value: 0x0B3E
+    name: 'ISEO Serrature S.p.a.'
+
+  - value: 0x0B3D
+    name: 'REALTIMEID AS'
+
+  - value: 0x0B3C
+    name: 'Dodge Industrial, Inc.'
+
+  - value: 0x0B3B
+    name: 'AIC semiconductor (Shanghai) Co., Ltd.'
+
+  - value: 0x0B3A
+    name: 'Impact Biosystems, Inc.'
+
+  - value: 0x0B39
+    name: 'Red 100 Lighting Co., ltd.'
+
+  - value: 0x0B38
+    name: 'WISYCOM S.R.L.'
+
+  - value: 0x0B37
+    name: 'Omnivoltaic Energy Solutions Limited Company'
+
+  - value: 0x0B36
+    name: 'SINTEF'
+
+  - value: 0x0B35
+    name: 'BH SENS'
+
+  - value: 0x0B34
+    name: 'CONZUMEX INDUSTRIES PRIVATE LIMITED'
+
+  - value: 0x0B33
+    name: 'ARMATURA LLC'
+
+  - value: 0x0B32
+    name: 'Hala Systems, Inc.'
+
+  - value: 0x0B31
+    name: 'Silver Wolf Vehicles Inc.'
+
+  - value: 0x0B30
+    name: 'ART SPA'
+
+  - value: 0x0B2F
+    name: 'Duke Manufacturing Co'
+
+  - value: 0x0B2E
+    name: 'MOCA System Inc.'
+
+  - value: 0x0B2D
+    name: 'REDARC ELECTRONICS PTY LTD'
+
+  - value: 0x0B2C
+    name: 'ILLUMAGEAR, Inc.'
+
+  - value: 0x0B2B
+    name: 'MAINBOT'
+
+  - value: 0x0B2A
+    name: 'ACL Airshop B.V.'
+
+  - value: 0x0B29
+    name: 'Tech-Venom Entertainment Private Limited'
+
+  - value: 0x0B28
+    name: 'CHACON'
+
+  - value: 0x0B27
+    name: 'Lumi United Technology Co., Ltd'
+
+  - value: 0x0B26
+    name: 'Baracoda Daily Healthtech.'
+
+  - value: 0x0B25
+    name: 'NIBROTECH LTD'
+
+  - value: 0x0B24
+    name: 'BeiJing ZiJie TiaoDong KeJi Co.,Ltd.'
+
+  - value: 0x0B23
+    name: 'iRhythm Technologies, Inc.'
+
+  - value: 0x0B22
+    name: 'Hygiene IQ, LLC.'
+
+  - value: 0x0B21
+    name: 'ams AG'
+
+  - value: 0x0B20
+    name: 'TKH Security B.V.'
+
+  - value: 0x0B1F
+    name: 'Beijing ESWIN Computing Technology Co., Ltd.'
+
+  - value: 0x0B1E
+    name: 'PB INC.'
+
+  - value: 0x0B1D
+    name: 'Accelerated Systems'
+
+  - value: 0x0B1C
+    name: 'Nanoleq AG'
+
+  - value: 0x0B1B
+    name: 'Enerpac Tool Group Corp.'
+
+  - value: 0x0B1A
+    name: 'Roca Sanitario, S.A.'
+
+  - value: 0x0B19
+    name: 'WBS PROJECT H PTY LTD'
+
+  - value: 0x0B18
+    name: 'DECATHLON SE'
+
+  - value: 0x0B17
+    name: 'SIG SAUER, INC.'
+
+  - value: 0x0B16
+    name: 'Guard RFID Solutions Inc.'
+
+  - value: 0x0B15
+    name: 'NAOS JAPAN K.K.'
+
+  - value: 0x0B14
+    name: 'Olumee'
+
+  - value: 0x0B13
+    name: 'IOTOOLS'
+
+  - value: 0x0B12
+    name: 'ToughBuilt Industries LLC'
+
+  - value: 0x0B11
+    name: 'ThermoWorks, Inc.'
+
+  - value: 0x0B10
+    name: 'Alfa Laval Corporate AB'
+
+  - value: 0x0B0F
+    name: 'B.E.A. S.A.'
+
+  - value: 0x0B0E
+    name: 'Minebea Access Solutions Inc.'
+
+  - value: 0x0B0D
+    name: 'SANYO DENKO Co.,Ltd.'
+
+  - value: 0x0B0C
+    name: 'BluPeak'
+
+  - value: 0x0B0B
+    name: 'Sanistaal A/S'
+
+  - value: 0x0B0A
+    name: 'Belun Technology Company Limited'
+
+  - value: 0x0B09
+    name: 'soonisys'
+
+  - value: 0x0B08
+    name: 'Shenzhen Qianfenyi Intelligent Technology Co., LTD'
+
+  - value: 0x0B07
+    name: 'Workaround Gmbh'
+
+  - value: 0x0B06
+    name: 'FAZUA GmbH'
+
+  - value: 0x0B05
+    name: 'Marquardt GmbH'
+
+  - value: 0x0B04
+    name: 'I-PERCUT'
+
+  - value: 0x0B03
+    name: 'Precision Triathlon Systems Limited'
+
+  - value: 0x0B02
+    name: 'IORA Technology Development Ltd. Sti.'
+
+  - value: 0x0B01
+    name: 'RESIDEO TECHNOLOGIES, INC.'
+
+  - value: 0x0B00
+    name: 'Flaircomm Microelectronics Inc.'
+
+  - value: 0x0AFF
+    name: 'FUSEAWARE LIMITED'
+
+  - value: 0x0AFE
+    name: 'Earda Technologies Co.,Ltd'
+
+  - value: 0x0AFD
+    name: 'Weber Sensors, LLC'
+
+  - value: 0x0AFC
+    name: 'Cerebrum Sensor Technologies Inc.'
+
+  - value: 0x0AFB
+    name: 'SMT ELEKTRONIK GmbH'
+
+  - value: 0x0AFA
+    name: 'Chengdu Ambit Technology Co., Ltd.'
+
+  - value: 0x0AF9
+    name: 'Unisto AG'
+
+  - value: 0x0AF8
+    name: 'First Design System Inc.'
+
+  - value: 0x0AF7
+    name: 'Irdeto'
+
+  - value: 0x0AF6
+    name: 'AMETEK, Inc.'
+
+  - value: 0x0AF5
+    name: 'Unitech Electronic Inc.'
+
+  - value: 0x0AF4
+    name: 'Radioworks Microelectronics PTY LTD'
+
+  - value: 0x0AF3
+    name: '701x Inc.'
+
+  - value: 0x0AF2
+    name: 'Shanghai All Link Microelectronics Co.,Ltd'
+
+  - value: 0x0AF1
+    name: 'CRADERS,CO.,LTD'
+
+  - value: 0x0AF0
+    name: 'Leupold & Stevens, Inc.'
+
+  - value: 0x0AEF
+    name: 'GLP German Light Products GmbH'
+
+  - value: 0x0AEE
+    name: 'Velentium, LLC'
+
+  - value: 0x0AED
+    name: 'Saxonar GmbH'
+
+  - value: 0x0AEC
+    name: 'FUTEK ADVANCED SENSOR TECHNOLOGY, INC'
+
+  - value: 0x0AEB
+    name: 'Square, Inc.'
+
+  - value: 0x0AEA
+    name: 'Borda Technology'
+
+  - value: 0x0AE9
+    name: 'FLIR Systems AB'
+
+  - value: 0x0AE8
+    name: 'LEVEL, s.r.o.'
+
+  - value: 0x0AE7
+    name: 'Sunplus Technology Co., Ltd.'
+
+  - value: 0x0AE6
+    name: 'Hexology'
+
+  - value: 0x0AE5
+    name: 'unu GmbH'
+
+  - value: 0x0AE4
+    name: 'DALI Alliance'
+
+  - value: 0x0AE3
+    name: 'GlobalMed'
+
+  - value: 0x0AE2
+    name: 'IMATRIX SYSTEMS, INC.'
+
+  - value: 0x0AE1
+    name: 'ChengDu ForThink Technology Co., Ltd.'
+
+  - value: 0x0AE0
+    name: 'Viceroy Devices Corporation'
+
+  - value: 0x0ADF
+    name: 'Douglas Dynamics L.L.C.'
+
+  - value: 0x0ADE
+    name: 'Vocera Communications, Inc.'
+
+  - value: 0x0ADD
+    name: 'Boss Audio'
+
+  - value: 0x0ADC
+    name: 'Duravit AG'
+
+  - value: 0x0ADB
+    name: 'Reelables, Inc.'
+
+  - value: 0x0ADA
+    name: 'Codefabrik GmbH'
+
+  - value: 0x0AD9
+    name: 'Shenzhen Aimore. Co.,Ltd'
+
+  - value: 0x0AD8
+    name: 'Franz Kaldewei GmbH&Co KG'
+
+  - value: 0x0AD7
+    name: 'AL-KO Geraete GmbH'
+
+  - value: 0x0AD6
+    name: 'nymea GmbH'
+
+  - value: 0x0AD5
+    name: 'Streamit B.V.'
+
+  - value: 0x0AD4
+    name: 'Zhuhai Pantum Electronisc Co., Ltd'
+
+  - value: 0x0AD3
+    name: 'SSV Software Systems GmbH'
+
+  - value: 0x0AD2
+    name: 'Lautsprecher Teufel GmbH'
+
+  - value: 0x0AD1
+    name: 'EAGLE KINGDOM TECHNOLOGIES LIMITED'
+
+  - value: 0x0AD0
+    name: 'Nordic Strong ApS'
+
+  - value: 0x0ACF
+    name: 'CACI Technologies'
+
+  - value: 0x0ACE
+    name: 'KOBATA GAUGE MFG. CO., LTD.'
+
+  - value: 0x0ACD
+    name: 'Visuallex Sport International Limited'
+
+  - value: 0x0ACC
+    name: 'Nuvoton'
+
+  - value: 0x0ACB
+    name: 'ise Individuelle Software und Elektronik GmbH'
+
+  - value: 0x0ACA
+    name: 'Shenzhen CoolKit Technology Co., Ltd'
+
+  - value: 0x0AC9
+    name: 'Swedlock AB'
+
+  - value: 0x0AC8
+    name: 'Keepin Co., Ltd.'
+
+  - value: 0x0AC7
+    name: 'Chengdu Aich Technology Co.,Ltd'
+
+  - value: 0x0AC6
+    name: 'Barnes Group Inc.'
+
+  - value: 0x0AC5
+    name: 'Flexoptix GmbH'
+
+  - value: 0x0AC4
+    name: 'CODIUM'
+
+  - value: 0x0AC3
+    name: 'Kenzen, Inc.'
+
+  - value: 0x0AC2
+    name: 'RealMega Microelectronics technology (Shanghai) Co. Ltd.'
+
+  - value: 0x0AC1
+    name: 'Shenzhen Jingxun Technology Co., Ltd.'
+
+  - value: 0x0AC0
+    name: 'Omni-ID USA, INC.'
+
+  - value: 0x0ABF
+    name: 'PAUL HARTMANN AG'
+
+  - value: 0x0ABE
+    name: 'Robkoo Information & Technologies Co., Ltd.'
+
+  - value: 0x0ABD
+    name: 'Inventas AS'
+
+  - value: 0x0ABC
+    name: 'KCCS Mobile Engineering Co., Ltd.'
+
+  - value: 0x0ABB
+    name: 'R-DAS, s.r.o.'
+
+  - value: 0x0ABA
+    name: 'Open Bionics Ltd.'
+
+  - value: 0x0AB9
+    name: 'STL'
+
+  - value: 0x0AB8
+    name: 'Sens.ai Incorporated'
+
+  - value: 0x0AB7
+    name: 'LogTag North America Inc.'
+
+  - value: 0x0AB6
+    name: 'Xenter, Inc.'
+
+  - value: 0x0AB5
+    name: 'Elstat Electronics Ltd.'
+
+  - value: 0x0AB4
+    name: 'Ellenby Technologies, Inc.'
+
+  - value: 0x0AB3
+    name: 'INNER RANGE PTY. LTD.'
+
+  - value: 0x0AB2
+    name: 'TouchTronics, Inc.'
+
+  - value: 0x0AB1
+    name: 'InVue Security Products Inc'
+
+  - value: 0x0AB0
+    name: 'Visiontronic s.r.o.'
+
+  - value: 0x0AAF
+    name: 'AIAIAI ApS'
+
+  - value: 0x0AAE
+    name: 'PS Engineering, Inc.'
+
+  - value: 0x0AAD
+    name: 'Adevo Consulting AB'
+
+  - value: 0x0AAC
+    name: 'OSM HK Limited'
+
+  - value: 0x0AAB
+    name: 'Anhui Listenai Co'
+
+  - value: 0x0AAA
+    name: 'Computime International Ltd'
+
+  - value: 0x0AA9
+    name: 'Spintly, Inc.'
+
+  - value: 0x0AA8
+    name: 'Zencontrol Pty Ltd'
+
+  - value: 0x0AA7
+    name: 'Urbanista AB'
+
+  - value: 0x0AA6
+    name: 'Realityworks, inc.'
+
+  - value: 0x0AA5
+    name: 'Shenzhen Uascent Technology Co., Ltd'
+
+  - value: 0x0AA4
+    name: 'FAZEPRO LLC'
+
+  - value: 0x0AA3
+    name: 'DIC Corporation'
+
+  - value: 0x0AA2
+    name: 'Care Bloom, LLC'
+
+  - value: 0x0AA1
+    name: 'LINCOGN TECHNOLOGY CO. LIMITED'
+
+  - value: 0x0AA0
+    name: 'Loy Tec electronics GmbH'
+
+  - value: 0x0A9F
+    name: 'ista International GmbH'
+
+  - value: 0x0A9E
+    name: 'LifePlus, Inc.'
+
+  - value: 0x0A9D
+    name: 'Canon Finetech Nisca Inc.'
+
+  - value: 0x0A9C
+    name: "Xi'an Fengyu Information Technology Co., Ltd."
+
+  - value: 0x0A9B
+    name: 'Eello LLC'
+
+  - value: 0x0A9A
+    name: 'TEMKIN ASSOCIATES, LLC'
+
+  - value: 0x0A99
+    name: 'Shanghai high-flying electronics technology Co.,Ltd'
+
+  - value: 0x0A98
+    name: 'Foil, Inc.'
+
+  - value: 0x0A97
+    name: 'SensTek'
+
+  - value: 0x0A96
+    name: 'Lightricity Ltd'
+
+  - value: 0x0A95
+    name: 'Pamex Inc.'
+
+  - value: 0x0A94
+    name: 'OOBIK Inc.'
+
+  - value: 0x0A93
+    name: 'GiPStech S.r.l.'
+
+  - value: 0x0A92
+    name: 'Carestream Dental LLC'
+
+  - value: 0x0A91
+    name: 'Monarch International Inc.'
+
+  - value: 0x0A90
+    name: 'Shenzhen Grandsun Electronic Co.,Ltd.'
+
+  - value: 0x0A8F
+    name: 'TOTO LTD.'
+
+  - value: 0x0A8E
+    name: 'Perfect Company'
+
+  - value: 0x0A8D
+    name: 'JCM TECHNOLOGIES S.A.'
+
+  - value: 0x0A8C
+    name: 'DelpSys, s.r.o.'
+
+  - value: 0x0A8B
+    name: 'SANlight GmbH'
+
+  - value: 0x0A8A
+    name: 'HAINBUCH GMBH SPANNENDE TECHNIK'
+
+  - value: 0x0A89
+    name: 'SES-Imagotag'
+
+  - value: 0x0A88
+    name: 'PSA Peugeot Citroen'
+
+  - value: 0x0A87
+    name: 'Shanghai Smart System Technology Co., Ltd'
+
+  - value: 0x0A86
+    name: 'ALIZENT International'
+
+  - value: 0x0A85
+    name: 'Snowball Technology Co., Ltd.'
+
+  - value: 0x0A84
+    name: 'Greennote Inc,'
+
+  - value: 0x0A83
+    name: 'Rivata, Inc.'
+
+  - value: 0x0A82
+    name: 'Corsair'
+
+  - value: 0x0A81
+    name: 'Universal Biosensors Pty Ltd'
+
+  - value: 0x0A80
+    name: 'Cleer Limited'
+
+  - value: 0x0A7F
+    name: 'Intuity Medical'
+
+  - value: 0x0A7E
+    name: 'KEBA Handover Automation GmbH'
+
+  - value: 0x0A7D
+    name: 'Freedman Electronics Pty Ltd'
+
+  - value: 0x0A7C
+    name: 'WAFERLOCK'
+
+  - value: 0x0A7B
+    name: 'UniqAir Oy'
+
+  - value: 0x0A7A
+    name: 'Emlid Limited'
+
+  - value: 0x0A79
+    name: 'Webasto SE'
+
+  - value: 0x0A78
+    name: 'Shenzhen Sunricher Technology Limited'
+
+  - value: 0x0A77
+    name: 'AXTRO PTE. LTD.'
+
+  - value: 0x0A76
+    name: 'Synaptics Incorporated'
+
+  - value: 0x0A75
+    name: 'Delta Cycle Corporation'
+
+  - value: 0x0A74
+    name: 'MICROSON S.A.'
+
+  - value: 0x0A73
+    name: 'Innohome Oy'
+
+  - value: 0x0A72
+    name: 'Jumo GmbH & Co. KG'
+
+  - value: 0x0A71
+    name: 'Senquip Pty Ltd'
+
+  - value: 0x0A70
+    name: 'Ooma'
+
+  - value: 0x0A6F
+    name: 'Warner Bros.'
+
+  - value: 0x0A6E
+    name: 'Pac Sane Limited'
+
+  - value: 0x0A6D
+    name: 'KUUKANJYOKIN Co.,Ltd.'
+
+  - value: 0x0A6C
+    name: 'Pokkels'
+
+  - value: 0x0A6B
+    name: 'Olympic Ophthalmics, Inc.'
+
+  - value: 0x0A6A
+    name: 'Scribble Design Inc.'
+
+  - value: 0x0A69
+    name: 'HAPPIEST BABY, INC.'
+
+  - value: 0x0A68
+    name: 'Focus Ingenieria SRL'
+
+  - value: 0x0A67
+    name: 'Beijing SuperHexa Century Technology CO. Ltd'
+
+  - value: 0x0A66
+    name: 'JUSTMORPH PTE. LTD.'
+
+  - value: 0x0A65
+    name: 'Lytx, INC.'
+
+  - value: 0x0A64
+    name: 'Geopal system A/S'
+
+  - value: 0x0A63
+    name: 'Gremsy JSC'
+
+  - value: 0x0A62
+    name: 'MOKO TECHNOLOGY Ltd'
+
+  - value: 0x0A61
+    name: 'Smart Parks B.V.'
+
+  - value: 0x0A60
+    name: 'DATANG SEMICONDUCTOR TECHNOLOGY CO.,LTD'
+
+  - value: 0x0A5F
+    name: 'stryker'
+
+  - value: 0x0A5E
+    name: 'LaceClips llc'
+
+  - value: 0x0A5D
+    name: 'MG Energy Systems B.V.'
+
+  - value: 0x0A5C
+    name: 'Innovative Design Labs Inc.'
+
+  - value: 0x0A5B
+    name: 'LEGIC Identsystems AG'
+
+  - value: 0x0A5A
+    name: 'Sontheim Industrie Elektronik GmbH'
+
+  - value: 0x0A59
+    name: 'TourBuilt, LLC'
+
+  - value: 0x0A58
+    name: 'Indigo Diabetes'
+
+  - value: 0x0A57
+    name: 'Meizhou Guo Wei Electronics Co., Ltd'
+
+  - value: 0x0A56
+    name: 'ambie'
+
+  - value: 0x0A55
+    name: 'Inugo Systems Limited'
+
+  - value: 0x0A54
+    name: 'SQL Technologies Corp.'
+
+  - value: 0x0A53
+    name: 'KKM COMPANY LIMITED'
+
+  - value: 0x0A52
+    name: 'Follow Sense Europe B.V.'
+
+  - value: 0x0A51
+    name: 'CSIRO'
+
+  - value: 0x0A50
+    name: 'Nextscape Inc.'
+
+  - value: 0x0A4F
+    name: 'VANMOOF Global Holding B.V.'
+
+  - value: 0x0A4E
+    name: 'Toytec Corporation'
+
+  - value: 0x0A4D
+    name: 'Lockn Technologies Private Limited'
+
+  - value: 0x0A4C
+    name: 'SiFli Technologies (shanghai) Inc.'
+
+  - value: 0x0A4B
+    name: 'MistyWest Energy and Transport Ltd.'
+
+  - value: 0x0A4A
+    name: 'Map Large, Inc.'
+
+  - value: 0x0A49
+    name: 'Venture Research Inc.'
+
+  - value: 0x0A48
+    name: 'JRC Mobility Inc.'
+
+  - value: 0x0A47
+    name: 'The Wand Company Ltd'
+
+  - value: 0x0A46
+    name: 'Beijing HC-Infinite Technology Limited'
+
+  - value: 0x0A45
+    name: '3SI Security Systems, Inc'
+
+  - value: 0x0A44
+    name: 'Novidan, Inc.'
+
+  - value: 0x0A43
+    name: 'Busch Systems International Inc.'
+
+  - value: 0x0A42
+    name: 'Motionalysis, Inc.'
+
+  - value: 0x0A41
+    name: 'OPEX Corporation'
+
+  - value: 0x0A40
+    name: 'GEWISS S.p.A.'
+
+  - value: 0x0A3F
+    name: 'Shenzhen Yopeak Optoelectronics Technology Co., Ltd.'
+
+  - value: 0x0A3E
+    name: 'Hefei Yunlian Semiconductor Co., Ltd'
+
+  - value: 0x0A3D
+    name: 'DELABIE'
+
+  - value: 0x0A3C
+    name: 'Siteco GmbH'
+
+  - value: 0x0A3B
+    name: 'Galileo Technology Limited'
+
+  - value: 0x0A3A
+    name: 'Incotex Co. Ltd.'
+
+  - value: 0x0A39
+    name: 'BLUETICKETING SRL'
+
+  - value: 0x0A38
+    name: 'Bouffalo Lab (Nanjing)., Ltd.'
+
+  - value: 0x0A37
+    name: '2587702 Ontario Inc.'
+
+  - value: 0x0A36
+    name: 'NGK SPARK PLUG CO., LTD.'
+
+  - value: 0x0A35
+    name: 'safectory GmbH'
+
+  - value: 0x0A34
+    name: 'Luxer Corporation'
+
+  - value: 0x0A33
+    name: 'WMF AG'
+
+  - value: 0x0A32
+    name: 'Pinnacle Technology, Inc.'
+
+  - value: 0x0A31
+    name: 'Nevro Corp.'
+
+  - value: 0x0A30
+    name: 'Air-Weigh'
+
+  - value: 0x0A2F
+    name: 'Instamic, Inc.'
+
+  - value: 0x0A2E
+    name: 'Zuma Array Limited'
+
+  - value: 0x0A2D
+    name: 'Shenzhen Feasycom Technology Co., Ltd.'
+
+  - value: 0x0A2C
+    name: 'Shenzhen H&T Intelligent Control Co., Ltd'
+
+  - value: 0x0A2B
+    name: 'PaceBait IVS'
+
+  - value: 0x0A2A
+    name: 'Yamaha Corporation'
+
+  - value: 0x0A29
+    name: 'Worthcloud Technology Co.,Ltd'
+
+  - value: 0x0A28
+    name: 'NanoFlex Power Corporation'
+
+  - value: 0x0A27
+    name: 'AYU DEVICES PRIVATE LIMITED'
+
+  - value: 0x0A26
+    name: 'Louis Vuitton'
+
+  - value: 0x0A25
+    name: 'Eran Financial Services LLC'
+
+  - value: 0x0A24
+    name: 'Atmosic Technologies, Inc.'
+
+  - value: 0x0A23
+    name: 'BIXOLON CO.,LTD'
+
+  - value: 0x0A22
+    name: 'DAIICHIKOSHO CO., LTD.'
+
+  - value: 0x0A21
+    name: 'Apollogic Sp. z o.o.'
+
+  - value: 0x0A20
+    name: 'Jiangxi Innotech Technology Co., Ltd'
+
+  - value: 0x0A1F
+    name: 'DeVilbiss Healthcare LLC'
+
+  - value: 0x0A1E
+    name: 'CombiQ AB'
+
+  - value: 0x0A1D
+    name: 'API-K'
+
+  - value: 0x0A1C
+    name: 'INPEAK S.C.'
+
+  - value: 0x0A1B
+    name: 'Embrava Pty Ltd'
+
+  - value: 0x0A1A
+    name: 'Link Labs, Inc.'
+
+  - value: 0x0A19
+    name: 'Maxell, Ltd.'
+
+  - value: 0x0A18
+    name: 'Cambridge Animal Technologies Ltd'
+
+  - value: 0x0A17
+    name: 'Plume Design Inc'
+
+  - value: 0x0A16
+    name: 'RIDE VISION LTD'
+
+  - value: 0x0A15
+    name: 'Syng Inc'
+
+  - value: 0x0A14
+    name: 'CROXEL, INC.'
+
+  - value: 0x0A13
+    name: 'Tec4med LifeScience GmbH'
+
+  - value: 0x0A12
+    name: 'Dyson Technology Limited'
+
+  - value: 0x0A11
+    name: 'Sensolus'
+
+  - value: 0x0A10
+    name: 'SUBARU Corporation'
+
+  - value: 0x0A0F
+    name: 'LIXIL Corporation'
+
+  - value: 0x0A0E
+    name: 'Roland Corporation'
+
+  - value: 0x0A0D
+    name: 'Blue Peacock GmbH'
+
+  - value: 0x0A0C
+    name: 'Shanghai Yidian Intelligent Technology Co., Ltd.'
+
+  - value: 0x0A0B
+    name: 'SIANA Systems'
+
+  - value: 0x0A0A
+    name: 'Volan Technology Inc.'
+
+  - value: 0x0A09
+    name: 'ECCT'
+
+  - value: 0x0A08
+    name: 'Oras Oy'
+
+  - value: 0x0A07
+    name: 'Reflow Pty Ltd'
+
+  - value: 0x0A06
+    name: 'Shanghai wuqi microelectronics Co.,Ltd'
+
+  - value: 0x0A05
+    name: 'Southwire Company, LLC'
+
+  - value: 0x0A04
+    name: 'Flosonics Medical'
+
+  - value: 0x0A03
+    name: 'donutrobotics Co., Ltd.'
+
+  - value: 0x0A02
+    name: 'Ayxon-Dynamics GmbH'
+
+  - value: 0x0A01
+    name: 'Cleveron AS'
+
+  - value: 0x0A00
+    name: 'Ampler Bikes OU'
+
+  - value: 0x09FF
+    name: 'AIRSTAR'
+
+  - value: 0x09FE
+    name: 'Lichtvision Engineering GmbH'
+
+  - value: 0x09FD
+    name: 'Keep Technologies, Inc.'
+
+  - value: 0x09FC
+    name: 'Confidex'
+
+  - value: 0x09FB
+    name: 'TOITU CO., LTD.'
+
+  - value: 0x09FA
+    name: 'Listen Technologies Corporation'
+
+  - value: 0x09F9
+    name: 'Hangzhou Yaguan Technology Co. LTD'
+
+  - value: 0x09F8
+    name: 'R.O. S.R.L.'
+
+  - value: 0x09F7
+    name: 'SENSATEC Co., Ltd.'
+
+  - value: 0x09F6
+    name: 'Mobile Action Technology Inc.'
+
+  - value: 0x09F5
+    name: 'OKI Electric Industry Co., Ltd'
+
+  - value: 0x09F4
+    name: 'Spectrum Technologies, Inc.'
+
+  - value: 0x09F3
+    name: 'Beijing Zero Zero Infinity Technology Co.,Ltd.'
+
+  - value: 0x09F2
+    name: 'Audeara Pty Ltd'
+
+  - value: 0x09F1
+    name: 'OM Digital Solutions Corporation'
+
+  - value: 0x09F0
+    name: 'WatchGas B.V.'
+
+  - value: 0x09EF
+    name: 'Steinel Solutions AG'
+
+  - value: 0x09EE
+    name: 'OJMAR SA'
+
+  - value: 0x09ED
+    name: 'Sibel Inc.'
+
+  - value: 0x09EC
+    name: 'Yukon advanced optics worldwide, UAB'
+
+  - value: 0x09EB
+    name: 'KEAN ELECTRONICS PTY LTD'
+
+  - value: 0x09EA
+    name: 'Athlos Oy'
+
+  - value: 0x09E9
+    name: 'LumenRadio AB'
+
+  - value: 0x09E8
+    name: 'Melange Systems Pvt. Ltd.'
+
+  - value: 0x09E7
+    name: 'Kabushikigaisha HANERON'
+
+  - value: 0x09E6
+    name: 'Masonite Corporation'
+
+  - value: 0x09E5
+    name: 'Mobilogix'
+
+  - value: 0x09E4
+    name: 'CPS AS'
+
+  - value: 0x09E3
+    name: 'Friday Home Aps'
+
+  - value: 0x09E2
+    name: 'Wuhan Linptech Co.,Ltd.'
+
+  - value: 0x09E1
+    name: 'Tag-N-Trac Inc'
+
+  - value: 0x09E0
+    name: 'Preddio Technologies Inc.'
+
+  - value: 0x09DF
+    name: 'Magnus Technology Sdn Bhd'
+
+  - value: 0x09DE
+    name: 'JLD Technology Solutions, LLC'
+
+  - value: 0x09DD
+    name: 'Innoware Development AB'
+
+  - value: 0x09DC
+    name: 'AON2 Ltd.'
+
+  - value: 0x09DB
+    name: 'Bionic Avionics Inc.'
+
+  - value: 0x09DA
+    name: 'Nagravision SA'
+
+  - value: 0x09D9
+    name: 'VivoSensMedical GmbH'
+
+  - value: 0x09D8
+    name: 'Synergy Tecnologia em Sistemas Ltda'
+
+  - value: 0x09D7
+    name: 'Coyotta'
+
+  - value: 0x09D6
+    name: 'EAR TEKNIK ISITME VE ODIOMETRI CIHAZLARI SANAYI VE TICARET ANONIM SIRKETI'
+
+  - value: 0x09D5
+    name: 'GEAR RADIO ELECTRONICS CORP.'
+
+  - value: 0x09D4
+    name: 'ORBIS Inc.'
+
+  - value: 0x09D3
+    name: 'HeartHero, inc.'
+
+  - value: 0x09D2
+    name: 'Temperature Sensitive Solutions Systems Sweden AB'
+
+  - value: 0x09D1
+    name: 'ABLEPAY TECHNOLOGIES AS'
+
+  - value: 0x09D0
+    name: 'Chess Wise B.V.'
+
+  - value: 0x09CF
+    name: 'BlueStreak IoT, LLC'
+
+  - value: 0x09CE
+    name: 'Julius Blum GmbH'
+
+  - value: 0x09CD
+    name: 'Blyott'
+
+  - value: 0x09CC
+    name: 'Senso4s d.o.o.'
+
+  - value: 0x09CB
+    name: 'Hx Engineering, LLC'
+
+  - value: 0x09CA
+    name: 'Mobitrace'
+
+  - value: 0x09C9
+    name: 'CrowdGlow Ltd'
+
+  - value: 0x09C8
+    name: 'XUNTONG'
+
+  - value: 0x09C7
+    name: 'Combustion, LLC'
+
+  - value: 0x09C6
+    name: 'Honor Device Co., Ltd.'
+
+  - value: 0x09C5
+    name: 'HungYi Microelectronics Co.,Ltd.'
+
+  - value: 0x09C4
+    name: 'UVISIO'
+
+  - value: 0x09C3
+    name: 'JAPAN TOBACCO INC.'
+
+  - value: 0x09C2
+    name: 'Universal Audio, Inc.'
+
+  - value: 0x09C1
+    name: 'Rosewill'
+
+  - value: 0x09C0
+    name: 'AnotherBrain inc.'
+
+  - value: 0x09BF
+    name: 'Span.IO, Inc.'
+
+  - value: 0x09BE
+    name: 'Vessel Ltd.'
+
+  - value: 0x09BD
+    name: "Centre Suisse d'Electronique et de Microtechnique SA"
+
+  - value: 0x09BC
+    name: 'Aerosens LLC'
+
+  - value: 0x09BB
+    name: 'SkyStream Corporation'
+
+  - value: 0x09BA
+    name: 'Elimo Engineering Ltd'
+
+  - value: 0x09B9
+    name: 'SAVOY ELECTRONIC LIGHTING'
+
+  - value: 0x09B8
+    name: 'PlayerData Limited'
+
+  - value: 0x09B7
+    name: 'Bout Labs, LLC'
+
+  - value: 0x09B6
+    name: 'Pegasus Technologies, Inc.'
+
+  - value: 0x09B5
+    name: 'AUTEC Gesellschaft fuer Automationstechnik mbH'
+
+  - value: 0x09B4
+    name: 'PentaLock Aps.'
+
+  - value: 0x09B3
+    name: 'BlueX Microelectronics Corp Ltd.'
+
+  - value: 0x09B2
+    name: 'DYPHI'
+
+  - value: 0x09B1
+    name: 'BLINQY'
+
+  - value: 0x09B0
+    name: 'Deublin Company, LLC'
+
+  - value: 0x09AF
+    name: 'ifLink Open Community'
+
+  - value: 0x09AE
+    name: 'Pozyx NV'
+
+  - value: 0x09AD
+    name: 'Narhwall Inc.'
+
+  - value: 0x09AC
+    name: 'Ambiq'
+
+  - value: 0x09AB
+    name: 'DashLogic, Inc.'
+
+  - value: 0x09AA
+    name: 'PHOTODYNAMIC INCORPORATED'
+
+  - value: 0x09A9
+    name: 'Nippon Ceramic Co.,Ltd.'
+
+  - value: 0x09A8
+    name: 'KHN Solutions LLC'
+
+  - value: 0x09A7
+    name: 'Paybuddy ApS'
+
+  - value: 0x09A6
+    name: 'BEIJING ELECTRIC VEHICLE CO.,LTD'
+
+  - value: 0x09A5
+    name: 'Security Enhancement Systems, LLC'
+
+  - value: 0x09A4
+    name: 'KUMHO ELECTRICS, INC'
+
+  - value: 0x09A3
+    name: 'ARDUINO SA'
+
+  - value: 0x09A2
+    name: 'ENGAGENOW DATA SCIENCES PRIVATE LIMITED'
+
+  - value: 0x09A1
+    name: 'VOS Systems, LLC'
+
+  - value: 0x09A0
+    name: 'Proof Diagnostics, Inc.'
+
+  - value: 0x099F
+    name: 'Koya Medical, Inc.'
+
+  - value: 0x099E
+    name: 'Step One Limited'
+
+  - value: 0x099D
+    name: 'YKK AP Inc.'
+
+  - value: 0x099C
+    name: 'deister electronic GmbH'
+
+  - value: 0x099B
+    name: 'Sendum Wireless Corporation'
+
+  - value: 0x099A
+    name: 'New Audio LLC'
+
+  - value: 0x0999
+    name: 'eTactica ehf'
+
+  - value: 0x0998
+    name: 'Pixie Dust Technologies, Inc.'
+
+  - value: 0x0997
+    name: 'NextMind'
+
+  - value: 0x0996
+    name: 'C. & E. Fein GmbH'
+
+  - value: 0x0995
+    name: 'Bronkhorst High-Tech B.V.'
+
+  - value: 0x0994
+    name: 'VT42 Pty Ltd'
+
+  - value: 0x0993
+    name: 'Absolute Audio Labs B.V.'
+
+  - value: 0x0992
+    name: 'Big Kaiser Precision Tooling Ltd'
+
+  - value: 0x0991
+    name: 'Telenor ASA'
+
+  - value: 0x0990
+    name: 'Anton Paar GmbH'
+
+  - value: 0x098F
+    name: 'Aktiebolaget Regin'
+
+  - value: 0x098E
+    name: 'ADVEEZ'
+
+  - value: 0x098D
+    name: 'C3-WIRELESS, LLC'
+
+  - value: 0x098C
+    name: 'bGrid B.V.'
+
+  - value: 0x098B
+    name: 'Mequonic Engineering, S.L.'
+
+  - value: 0x098A
+    name: 'Biovigil'
+
+  - value: 0x0989
+    name: 'WIKA Alexander Wiegand SE & Co.KG'
+
+  - value: 0x0988
+    name: 'BHM-Tech Produktionsgesellschaft m.b.H'
+
+  - value: 0x0987
+    name: 'TSE BRAKES, INC.'
+
+  - value: 0x0986
+    name: 'Cello Hill, LLC'
+
+  - value: 0x0985
+    name: 'Lumos Health Inc.'
+
+  - value: 0x0984
+    name: 'TeraTron GmbH'
+
+  - value: 0x0983
+    name: 'Feedback Sports LLC'
+
+  - value: 0x0982
+    name: 'ELPRO-BUCHS AG'
+
+  - value: 0x0981
+    name: 'Bernard Krone Holding SE & Co.KG'
+
+  - value: 0x0980
+    name: 'DEKRA TESTING AND CERTIFICATION, S.A.U.'
+
+  - value: 0x097F
+    name: 'ISEMAR S.R.L.'
+
+  - value: 0x097E
+    name: 'SonicSensory Inc'
+
+  - value: 0x097D
+    name: 'CLB B.V.'
+
+  - value: 0x097C
+    name: 'Thorley Industries, LLC'
+
+  - value: 0x097B
+    name: 'CTEK Sweden AB'
+
+  - value: 0x097A
+    name: 'CORE CORPORATION'
+
+  - value: 0x0979
+    name: 'BIOTRONIK SE & Co. KG'
+
+  - value: 0x0978
+    name: 'ZifferEins GmbH & Co. KG'
+
+  - value: 0x0977
+    name: 'TOYOTA motor corporation'
+
+  - value: 0x0976
+    name: 'Fauna Audio GmbH'
+
+  - value: 0x0975
+    name: 'BlueIOT(Beijing) Technology Co.,Ltd'
+
+  - value: 0x0974
+    name: 'ABEYE'
+
+  - value: 0x0973
+    name: 'Popit Oy'
+
+  - value: 0x0972
+    name: 'Closed Joint Stock Company "Zavod Flometr" ("Zavod Flometr" CJSC)'
+
+  - value: 0x0971
+    name: 'GA'
+
+  - value: 0x0970
+    name: 'IBA Dosimetry GmbH'
+
+  - value: 0x096F
+    name: 'Lund Motion Products, Inc.'
+
+  - value: 0x096E
+    name: 'Band Industries, inc.'
+
+  - value: 0x096D
+    name: 'Gunwerks, LLC'
+
+  - value: 0x096C
+    name: '9374-7319 Quebec inc'
+
+  - value: 0x096B
+    name: 'Guide ID B.V.'
+
+  - value: 0x096A
+    name: 'dricos, Inc.'
+
+  - value: 0x0969
+    name: 'Woan Technology (Shenzhen) Co., Ltd.'
+
+  - value: 0x0968
+    name: 'Actev Motors, Inc.'
+
+  - value: 0x0967
+    name: 'Neo Materials and Consulting Inc.'
+
+  - value: 0x0966
+    name: 'PointGuard, LLC'
+
+  - value: 0x0965
+    name: 'Asahi Kasei Corporation'
+
+  - value: 0x0964
+    name: 'Countrymate Technology Limited'
+
+  - value: 0x0963
+    name: 'Moonbird BV'
+
+  - value: 0x0962
+    name: 'GL Solutions K.K.'
+
+  - value: 0x0961
+    name: 'Linkura AB'
+
+  - value: 0x0960
+    name: 'Sena Technologies Inc.'
+
+  - value: 0x095F
+    name: 'NUANCE HEARING LTD'
+
+  - value: 0x095E
+    name: 'BioEchoNet inc.'
+
+  - value: 0x095D
+    name: 'Electronic Theatre Controls'
+
+  - value: 0x095C
+    name: 'LogiLube, LLC'
+
+  - value: 0x095B
+    name: 'Lismore Instruments Limited'
+
+  - value: 0x095A
+    name: 'Selekt Bilgisayar, lletisim Urunleri lnsaat Sanayi ve Ticaret Limited Sirketi'
+
+  - value: 0x0959
+    name: 'HerdDogg, Inc'
+
+  - value: 0x0958
+    name: 'ZTE Corporation'
+
+  - value: 0x0957
+    name: 'Ohsung Electronics'
+
+  - value: 0x0956
+    name: 'Kerlink'
+
+  - value: 0x0955
+    name: 'Breville Group'
+
+  - value: 0x0954
+    name: 'Julbo'
+
+  - value: 0x0953
+    name: 'LogiLube, LLC'
+
+  - value: 0x0952
+    name: 'Apptricity Corporation'
+
+  - value: 0x0951
+    name: 'PPRS'
+
+  - value: 0x0950
+    name: 'Capetech'
+
+  - value: 0x094F
+    name: 'Limited Liability Company "Mikrotikls"'
+
+  - value: 0x094E
+    name: 'PassiveBolt, Inc.'
+
+  - value: 0x094D
+    name: 'tkLABS INC.'
+
+  - value: 0x094C
+    name: 'GimmiSys GmbH'
+
+  - value: 0x094B
+    name: 'Kindeva Drug Delivery L.P.'
+
+  - value: 0x094A
+    name: 'Zwift, Inc.'
+
+  - value: 0x0949
+    name: 'Metronom Health Europe'
+
+  - value: 0x0948
+    name: 'Wearable Link Limited'
+
+  - value: 0x0947
+    name: 'First Light Technologies Ltd.'
+
+  - value: 0x0946
+    name: 'AMC International Alfa Metalcraft Corporation AG'
+
+  - value: 0x0945
+    name: 'Globe (Jiangsu) Co., Ltd'
+
+  - value: 0x0944
+    name: 'Agitron d.o.o.'
+
+  - value: 0x0942
+    name: 'TRANSSION HOLDINGS LIMITED'
+
+  - value: 0x0941
+    name: 'Rivian Automotive, LLC'
+
+  - value: 0x0940
+    name: 'Hero Workout GmbH'
+
+  - value: 0x093F
+    name: 'JEPICO Corporation'
+
+  - value: 0x093E
+    name: 'Catalyft Labs, Inc.'
+
+  - value: 0x093D
+    name: 'Adolf Wuerth GmbH & Co KG'
+
+  - value: 0x093C
+    name: 'Xenoma Inc.'
+
+  - value: 0x093B
+    name: 'ENSESO LLC'
+
+  - value: 0x093A
+    name: 'LinkedSemi Microelectronics (Xiamen) Co., Ltd'
+
+  - value: 0x0939
+    name: 'ASTEM Co.,Ltd.'
+
+  - value: 0x0938
+    name: 'Henway Technologies, LTD.'
+
+  - value: 0x0937
+    name: 'RealThingks GmbH'
+
+  - value: 0x0936
+    name: 'Elekon AG'
+
+  - value: 0x0935
+    name: 'Reconnect, Inc.'
+
+  - value: 0x0934
+    name: 'KiteSpring Inc.'
+
+  - value: 0x0933
+    name: 'SRAM'
+
+  - value: 0x0932
+    name: 'BarVision, LLC'
+
+  - value: 0x0931
+    name: 'BREATHINGS Co., Ltd.'
+
+  - value: 0x0930
+    name: 'James Walker RotaBolt Limited'
+
+  - value: 0x092F
+    name: 'C.O.B.O. SpA'
+
+  - value: 0x092E
+    name: 'PS GmbH'
+
+  - value: 0x092D
+    name: 'Leggett & Platt, Incorporated'
+
+  - value: 0x092C
+    name: 'PCI Private Limited'
+
+  - value: 0x092B
+    name: 'TekHome'
+
+  - value: 0x092A
+    name: 'Sappl Verwaltungs- und Betriebs GmbH'
+
+  - value: 0x0929
+    name: 'Qingdao Haier Technology Co., Ltd.'
+
+  - value: 0x0928
+    name: 'AiRISTA'
+
+  - value: 0x0927
+    name: 'ROOQ GmbH'
+
+  - value: 0x0926
+    name: 'Gooligum Technologies Pty Ltd'
+
+  - value: 0x0925
+    name: 'Yukai Engineering Inc.'
+
+  - value: 0x0924
+    name: 'Fundacion Tecnalia Research and Innovation'
+
+  - value: 0x0923
+    name: 'JSB TECH PTE LTD'
+
+  - value: 0x0922
+    name: 'Shanghai MXCHIP Information Technology Co., Ltd.'
+
+  - value: 0x0921
+    name: 'KAHA PTE. LTD.'
+
+  - value: 0x0920
+    name: 'Omnisense Limited'
+
+  - value: 0x091F
+    name: 'Myzee Technology'
+
+  - value: 0x091E
+    name: 'Melbot Studios, Sociedad Limitada'
+
+  - value: 0x091D
+    name: 'Innokind, Inc.'
+
+  - value: 0x091C
+    name: 'Oblamatik AG'
+
+  - value: 0x091B
+    name: 'Luminostics, Inc.'
+
+  - value: 0x091A
+    name: 'Albertronic BV'
+
+  - value: 0x0919
+    name: 'NO SMD LIMITED'
+
+  - value: 0x0918
+    name: 'Technosphere Labs Pvt. Ltd.'
+
+  - value: 0x0917
+    name: 'ASR Microelectronics(ShenZhen)Co., Ltd.'
+
+  - value: 0x0916
+    name: 'Ambient Sensors LLC'
+
+  - value: 0x0915
+    name: 'Honda Motor Co., Ltd.'
+
+  - value: 0x0914
+    name: 'INEO-SENSE'
+
+  - value: 0x0913
+    name: 'Braveheart Wireless, Inc.'
+
+  - value: 0x0912
+    name: 'Nerbio Medical Software Platforms Inc'
+
+  - value: 0x0911
+    name: 'Douglas Lighting Controls Inc.'
+
+  - value: 0x0910
+    name: 'ASR Microelectronics (Shanghai) Co., Ltd.'
+
+  - value: 0x090F
+    name: 'VC Inc.'
+
+  - value: 0x090E
+    name: 'OPTIMUSIOT TECH LLP'
+
+  - value: 0x090D
+    name: 'IOT Invent GmbH'
+
+  - value: 0x090C
+    name: 'Radiawave Technologies Co.,Ltd.'
+
+  - value: 0x090B
+    name: 'EMBR labs, INC'
+
+  - value: 0x090A
+    name: 'Zhuhai Hoksi Technology CO.,LTD'
+
+  - value: 0x0909
+    name: '70mai Co.,Ltd.'
+
+  - value: 0x0908
+    name: 'Pinpoint Innovations Limited'
+
+  - value: 0x0907
+    name: 'User Hello, LLC'
+
+  - value: 0x0906
+    name: 'Scope Logistical Solutions'
+
+  - value: 0x0905
+    name: 'Yandex Services AG'
+
+  - value: 0x0904
+    name: 'SUNCORPORATION'
+
+  - value: 0x0903
+    name: 'DATAMARS, Inc.'
+
+  - value: 0x0902
+    name: 'TSC Auto-ID Technology Co., Ltd.'
+
+  - value: 0x0901
+    name: 'Lucimed'
+
+  - value: 0x0900
+    name: 'Beijing Zizai Technology Co., LTD.'
+
+  - value: 0x08FF
+    name: 'Plastimold Products, Inc'
+
+  - value: 0x08FE
+    name: 'Ketronixs Sdn Bhd'
+
+  - value: 0x08FD
+    name: 'BioIntelliSense, Inc.'
+
+  - value: 0x08FC
+    name: 'Hill-Rom'
+
+  - value: 0x08FB
+    name: 'Darkglass Electronics Oy'
+
+  - value: 0x08FA
+    name: 'Troo Corporation'
+
+  - value: 0x08F9
+    name: 'Spacelabs Medical Inc.'
+
+  - value: 0x08F8
+    name: 'instagrid GmbH'
+
+  - value: 0x08F7
+    name: 'MTD Products Inc & Affiliates'
+
+  - value: 0x08F6
+    name: 'Dermal Photonics Corporation'
+
+  - value: 0x08F5
+    name: 'Tymtix Technologies Private Limited'
+
+  - value: 0x08F4
+    name: 'Kodimo Technologies Company Limited'
+
+  - value: 0x08F3
+    name: 'PSP - Pauli Services & Products GmbH'
+
+  - value: 0x08F2
+    name: 'Microoled'
+
+  - value: 0x08F1
+    name: 'The L.S. Starrett Company'
+
+  - value: 0x08F0
+    name: 'Joovv, Inc.'
+
+  - value: 0x08EF
+    name: 'Cumulus Digital Systems, Inc'
+
+  - value: 0x08EE
+    name: 'Askey Computer Corp.'
+
+  - value: 0x08ED
+    name: 'IMI Hydronic Engineering International SA'
+
+  - value: 0x08EC
+    name: 'Denso Corporation'
+
+  - value: 0x08EB
+    name: 'Beijing Big Moment Technology Co., Ltd.'
+
+  - value: 0x08EA
+    name: 'COWBELL ENGINEERING CO.,LTD.'
+
+  - value: 0x08E9
+    name: 'Taiwan Intelligent Home Corp.'
+
+  - value: 0x08E8
+    name: 'Naonext'
+
+  - value: 0x08E7
+    name: 'Barrot Technology Co.,Ltd.'
+
+  - value: 0x08E6
+    name: 'Eneso Tecnologia de Adaptacion S.L.'
+
+  - value: 0x08E5
+    name: 'Crowd Connected Ltd'
+
+  - value: 0x08E4
+    name: 'Rashidov ltd'
+
+  - value: 0x08E3
+    name: 'Republic Wireless, Inc.'
+
+  - value: 0x08E2
+    name: 'Shenzhen Simo Technology co. LTD'
+
+  - value: 0x08E1
+    name: 'KOZO KEIKAKU ENGINEERING Inc.'
+
+  - value: 0x08E0
+    name: 'Philia Technology'
+
+  - value: 0x08DF
+    name: 'IRIS OHYAMA CO.,LTD.'
+
+  - value: 0x08DE
+    name: 'TE Connectivity Corporation'
+
+  - value: 0x08DD
+    name: 'code-Q'
+
+  - value: 0x08DC
+    name: 'SHENZHEN AUKEY E BUSINESS CO., LTD'
+
+  - value: 0x08DB
+    name: 'Tertium Technology'
+
+  - value: 0x08DA
+    name: 'Miridia Technology Incorporated'
+
+  - value: 0x08D9
+    name: 'Pointr Labs Limited'
+
+  - value: 0x08D8
+    name: 'WARES'
+
+  - value: 0x08D7
+    name: 'Inovonics Corp'
+
+  - value: 0x08D6
+    name: 'Nome Oy'
+
+  - value: 0x08D5
+    name: 'KEYes'
+
+  - value: 0x08D4
+    name: 'ADATA Technology Co., LTD.'
+
+  - value: 0x08D3
+    name: 'Novel Bits, LLC'
+
+  - value: 0x08D2
+    name: 'Virscient Limited'
+
+  - value: 0x08D1
+    name: 'Sensovium Inc.'
+
+  - value: 0x08D0
+    name: 'ESTOM Infotech Kft.'
+
+  - value: 0x08CF
+    name: 'betternotstealmybike UG (with limited liability)'
+
+  - value: 0x08CE
+    name: 'ZIMI CORPORATION'
+
+  - value: 0x08CD
+    name: 'ifly'
+
+  - value: 0x08CC
+    name: 'TGM TECHNOLOGY CO., LTD.'
+
+  - value: 0x08CB
+    name: 'JT INNOVATIONS LIMITED'
+
+  - value: 0x08CA
+    name: 'Nubia Technology Co.,Ltd.'
+
+  - value: 0x08C9
+    name: 'Noventa AG'
+
+  - value: 0x08C8
+    name: 'Liteboxer Technologies Inc.'
+
+  - value: 0x08C7
+    name: 'Monadnock Systems Ltd.'
+
+  - value: 0x08C6
+    name: 'Integra Optics Inc'
+
+  - value: 0x08C5
+    name: 'J. Wagner GmbH'
+
+  - value: 0x08C4
+    name: 'CellAssist, LLC'
+
+  - value: 0x08C3
+    name: 'CHIPOLO d.o.o.'
+
+  - value: 0x08C2
+    name: 'Lindinvent AB'
+
+  - value: 0x08C1
+    name: 'Rayden.Earth LTD'
+
+  - value: 0x08C0
+    name: 'Accent Advanced Systems SLU'
+
+  - value: 0x08BF
+    name: 'SIRC Co., Ltd.'
+
+  - value: 0x08BE
+    name: 'ubisys technologies GmbH'
+
+  - value: 0x08BD
+    name: 'bf1systems limited'
+
+  - value: 0x08BC
+    name: 'Prevayl Limited'
+
+  - value: 0x08BB
+    name: 'Tokai-rika co.,ltd.'
+
+  - value: 0x08BA
+    name: 'HYPER ICE, INC.'
+
+  - value: 0x08B9
+    name: 'U-Shin Ltd.'
+
+  - value: 0x08B8
+    name: 'Check Technology Solutions LLC'
+
+  - value: 0x08B7
+    name: 'ABB Inc'
+
+  - value: 0x08B6
+    name: 'Boehringer Ingelheim Vetmedica GmbH'
+
+  - value: 0x08B5
+    name: 'TransferFi'
+
+  - value: 0x08B4
+    name: 'Sengled Co., Ltd.'
+
+  - value: 0x08B3
+    name: 'IONIQ Skincare GmbH & Co. KG'
+
+  - value: 0x08B2
+    name: 'PF SCHWEISSTECHNOLOGIE GMBH'
+
+  - value: 0x08B1
+    name: 'CORE|vision BV'
+
+  - value: 0x08B0
+    name: 'Trivedi Advanced Technologies LLC'
+
+  - value: 0x08AF
+    name: 'Polidea Sp. z o.o.'
+
+  - value: 0x08AE
+    name: 'Moticon ReGo AG'
+
+  - value: 0x08AD
+    name: 'Kayamatics Limited'
+
+  - value: 0x08AC
+    name: 'Topre Corporation'
+
+  - value: 0x08AB
+    name: 'Coburn Technology, LLC'
+
+  - value: 0x08AA
+    name: 'SZ DJI TECHNOLOGY CO.,LTD'
+
+  - value: 0x08A9
+    name: 'Fraunhofer IIS'
+
+  - value: 0x08A8
+    name: 'Shanghai Kfcube Inc'
+
+  - value: 0x08A7
+    name: 'TGR 1.618 Limited'
+
+  - value: 0x08A6
+    name: 'Intelligenceworks Inc.'
+
+  - value: 0x08A5
+    name: 'UMEHEAL Ltd'
+
+  - value: 0x08A4
+    name: 'Realme Chongqing Mobile Telecommunications Corp., Ltd.'
+
+  - value: 0x08A3
+    name: 'Hoffmann SE'
+
+  - value: 0x08A2
+    name: 'Epic Systems Co., Ltd.'
+
+  - value: 0x08A1
+    name: 'EXEO TECH CORPORATION'
+
+  - value: 0x08A0
+    name: 'Aclara Technologies LLC'
+
+  - value: 0x089F
+    name: 'Witschi Electronic Ltd'
+
+  - value: 0x089E
+    name: 'i-SENS, inc.'
+
+  - value: 0x089D
+    name: 'J-J.A.D.E. Enterprise LLC'
+
+  - value: 0x089C
+    name: 'Embedded Devices Co. Company'
+
+  - value: 0x089B
+    name: 'Saucon Technologies'
+
+  - value: 0x089A
+    name: 'Private limited company "Teltonika"'
+
+  - value: 0x0899
+    name: 'SFS unimarket AG'
+
+  - value: 0x0898
+    name: 'Sensibo, Inc.'
+
+  - value: 0x0897
+    name: 'Current Lighting Solutions LLC'
+
+  - value: 0x0896
+    name: 'Nokian Renkaat Oyj'
+
+  - value: 0x0895
+    name: 'Gimer medical'
+
+  - value: 0x0894
+    name: 'EPIFIT'
+
+  - value: 0x0893
+    name: 'Maytronics Ltd'
+
+  - value: 0x0892
+    name: 'Ingenieurbuero Birnfeld UG (haftungsbeschraenkt)'
+
+  - value: 0x0891
+    name: 'SmartWireless GmbH & Co. KG'
+
+  - value: 0x0890
+    name: 'NICHIEI INTEC CO., LTD.'
+
+  - value: 0x088F
+    name: 'Tait International Limited'
+
+  - value: 0x088E
+    name: 'GIGA-TMS INC'
+
+  - value: 0x088D
+    name: 'Soliton Systems K.K.'
+
+  - value: 0x088C
+    name: 'GB Solution co.,Ltd'
+
+  - value: 0x088B
+    name: 'Tricorder Arraay Technologies LLC'
+
+  - value: 0x088A
+    name: 'sclak s.r.l.'
+
+  - value: 0x0889
+    name: 'XANTHIO'
+
+  - value: 0x0888
+    name: 'EnPointe Fencing Pty Ltd'
+
+  - value: 0x0887
+    name: 'Hydro-Gear Limited Partnership'
+
+  - value: 0x0886
+    name: 'Movella Technologies B.V.'
+
+  - value: 0x0885
+    name: 'LEVOLOR INC'
+
+  - value: 0x0884
+    name: 'Controlid Industria, Comercio de Hardware e Servicos de Tecnologia Ltda'
+
+  - value: 0x0883
+    name: 'Wintersteiger AG'
+
+  - value: 0x0882
+    name: 'PSYONIC, Inc.'
+
+  - value: 0x0881
+    name: 'Optalert'
+
+  - value: 0x0880
+    name: 'imagiLabs AB'
+
+  - value: 0x087F
+    name: 'Phillips Connect Technologies LLC'
+
+  - value: 0x087E
+    name: '1bar.net Limited'
+
+  - value: 0x087D
+    name: 'Konftel AB'
+
+  - value: 0x087C
+    name: 'Crosscan GmbH'
+
+  - value: 0x087B
+    name: 'BYSTAMP'
+
+  - value: 0x087A
+    name: 'ZRF, LLC'
+
+  - value: 0x0879
+    name: 'MIZUNO Corporation'
+
+  - value: 0x0878
+    name: 'The Chamberlain Group, Inc.'
+
+  - value: 0x0877
+    name: 'Tome, Inc.'
+
+  - value: 0x0876
+    name: 'SmartResQ ApS'
+
+  - value: 0x0875
+    name: 'Berner International LLC'
+
+  - value: 0x0874
+    name: 'Treegreen Limited'
+
+  - value: 0x0873
+    name: 'Innophase Incorporated'
+
+  - value: 0x0872
+    name: '11 Health & Technologies Limited'
+
+  - value: 0x0871
+    name: 'Dension Elektronikai Kft.'
+
+  - value: 0x0870
+    name: 'Wyze Labs, Inc'
+
+  - value: 0x086F
+    name: 'Trackunit A/S'
+
+  - value: 0x086E
+    name: 'Vorwerk Elektrowerke GmbH & Co. KG'
+
+  - value: 0x086D
+    name: 'Biometrika d.o.o.'
+
+  - value: 0x086C
+    name: 'Revvo Technologies, Inc.'
+
+  - value: 0x086B
+    name: 'Pacific Track, LLC'
+
+  - value: 0x086A
+    name: 'Odic Incorporated'
+
+  - value: 0x0869
+    name: 'EVVA Sicherheitstechnologie GmbH'
+
+  - value: 0x0868
+    name: 'WIOsense GmbH & Co. KG'
+
+  - value: 0x0867
+    name: 'Western Digital Techologies, Inc.'
+
+  - value: 0x0866
+    name: 'LAONZ Co.,Ltd'
+
+  - value: 0x0865
+    name: 'Emergency Lighting Products Limited'
+
+  - value: 0x0864
+    name: 'Rafaelmicro'
+
+  - value: 0x0863
+    name: 'Yo-tronics Technology Co., Ltd.'
+
+  - value: 0x0862
+    name: 'SmartDrive'
+
+  - value: 0x0861
+    name: 'SmartSensor Labs Ltd'
+
+  - value: 0x0860
+    name: 'Alflex Products B.V.'
+
+  - value: 0x085F
+    name: 'COMPEGPS TEAM,SOCIEDAD LIMITADA'
+
+  - value: 0x085E
+    name: 'Krog Systems LLC'
+
+  - value: 0x085D
+    name: 'Guilin Zhishen Information Technology Co.,Ltd.'
+
+  - value: 0x085C
+    name: 'ACOS CO.,LTD.'
+
+  - value: 0x085B
+    name: 'Nisshinbo Micro Devices Inc.'
+
+  - value: 0x085A
+    name: 'DAKATECH'
+
+  - value: 0x0859
+    name: 'BlueUp'
+
+  - value: 0x0858
+    name: 'SOUNDBOKS'
+
+  - value: 0x0857
+    name: 'Parsyl Inc'
+
+  - value: 0x0856
+    name: 'Canopy Growth Corporation'
+
+  - value: 0x0855
+    name: 'Helios Sports, Inc.'
+
+  - value: 0x0854
+    name: 'Tap Sound System'
+
+  - value: 0x0853
+    name: 'Pektron Group Limited'
+
+  - value: 0x0852
+    name: 'Cognosos, Inc.'
+
+  - value: 0x0851
+    name: 'Subeca, Inc.'
+
+  - value: 0x0850
+    name: 'Yealink (Xiamen) Network Technology Co.,LTD'
+
+  - value: 0x084F
+    name: 'Embedded Fitness B.V.'
+
+  - value: 0x084E
+    name: 'Carol Cole Company'
+
+  - value: 0x084D
+    name: 'SafePort'
+
+  - value: 0x084C
+    name: 'ORSO Inc.'
+
+  - value: 0x084B
+    name: 'Biotechware SRL'
+
+  - value: 0x084A
+    name: 'ARCOM'
+
+  - value: 0x0849
+    name: 'Dopple Technologies B.V.'
+
+  - value: 0x0848
+    name: 'JUJU JOINTS CANADA CORP.'
+
+  - value: 0x0847
+    name: 'DNANUDGE LIMITED'
+
+  - value: 0x0846
+    name: 'USound GmbH'
+
+  - value: 0x0845
+    name: 'Dometic Corporation'
+
+  - value: 0x0844
+    name: 'Pepperl + Fuchs GmbH'
+
+  - value: 0x0843
+    name: 'FRAGRANCE DELIVERY TECHNOLOGIES LTD'
+
+  - value: 0x0842
+    name: 'Tangshan HongJia electronic technology co., LTD.'
+
+  - value: 0x0841
+    name: 'General Luminaire (Shanghai) Co., Ltd.'
+
+  - value: 0x0840
+    name: 'Down Range Systems LLC'
+
+  - value: 0x083F
+    name: 'D-Link Corp.'
+
+  - value: 0x083E
+    name: 'Zorachka LTD'
+
+  - value: 0x083D
+    name: 'Tokenize, Inc.'
+
+  - value: 0x083C
+    name: 'BeerTech LTD'
+
+  - value: 0x083B
+    name: 'Piaggio Fast Forward'
+
+  - value: 0x083A
+    name: 'BPW Bergische Achsen Kommanditgesellschaft'
+
+  - value: 0x0839
+    name: 'A puissance 3'
+
+  - value: 0x0838
+    name: 'Etymotic Research, Inc.'
+
+  - value: 0x0837
+    name: 'vivo Mobile Communication Co., Ltd.'
+
+  - value: 0x0836
+    name: 'Bitwards Oy'
+
+  - value: 0x0835
+    name: 'Canopy Growth Corporation'
+
+  - value: 0x0834
+    name: 'RIKEN KEIKI CO., LTD.,'
+
+  - value: 0x0833
+    name: 'Conneqtech B.V.'
+
+  - value: 0x0832
+    name: 'Intermotive,Inc.'
+
+  - value: 0x0831
+    name: 'Foxble, LLC'
+
+  - value: 0x0830
+    name: 'Core Health and Fitness LLC'
+
+  - value: 0x082F
+    name: 'Blippit AB'
+
+  - value: 0x082E
+    name: 'ABB S.p.A.'
+
+  - value: 0x082D
+    name: 'INCUS PERFORMANCE LTD.'
+
+  - value: 0x082C
+    name: 'INGICS TECHNOLOGY CO., LTD.'
+
+  - value: 0x082B
+    name: 'shenzhen fitcare electronics Co.,Ltd'
+
+  - value: 0x082A
+    name: 'Mitutoyo Corporation'
+
+  - value: 0x0829
+    name: 'HEXAGON METROLOGY DIVISION ROMER'
+
+  - value: 0x0828
+    name: 'Shanghai Suisheng Information Technology Co., Ltd.'
+
+  - value: 0x0827
+    name: 'Kickmaker'
+
+  - value: 0x0826
+    name: 'Hyundai Motor Company'
+
+  - value: 0x0825
+    name: 'CME PTE. LTD.'
+
+  - value: 0x0824
+    name: '8Power Limited'
+
+  - value: 0x0823
+    name: 'Nexite Ltd'
+
+  - value: 0x0822
+    name: 'adafruit industries'
+
+  - value: 0x0821
+    name: 'INOVA Geophysical, Inc.'
+
+  - value: 0x0820
+    name: 'Brilliant Home Technology, Inc.'
+
+  - value: 0x081F
+    name: 'eSenseLab LTD'
+
+  - value: 0x081E
+    name: 'iNFORM Technology GmbH'
+
+  - value: 0x081D
+    name: 'Potrykus Holdings and Development LLC'
+
+  - value: 0x081C
+    name: 'Bobrick Washroom Equipment, Inc.'
+
+  - value: 0x081B
+    name: 'DIM3'
+
+  - value: 0x081A
+    name: 'Shenzhen Conex'
+
+  - value: 0x0819
+    name: 'Hunter Douglas Inc'
+
+  - value: 0x0818
+    name: 'tatwah SA'
+
+  - value: 0x0817
+    name: 'Wangs Alliance Corporation'
+
+  - value: 0x0816
+    name: 'SPICA SYSTEMS LLC'
+
+  - value: 0x0815
+    name: 'SKC Inc'
+
+  - value: 0x0814
+    name: 'Ossur hf.'
+
+  - value: 0x0813
+    name: 'Flextronics International USA Inc.'
+
+  - value: 0x0812
+    name: 'Mstream Technologies., Inc.'
+
+  - value: 0x0811
+    name: 'Becker Antriebe GmbH'
+
+  - value: 0x0810
+    name: 'LECO Corporation'
+
+  - value: 0x080F
+    name: 'Paradox Engineering SA'
+
+  - value: 0x080E
+    name: 'TATTCOM LLC'
+
+  - value: 0x080D
+    name: 'Azbil Co.'
+
+  - value: 0x080C
+    name: 'Ingy B.V.'
+
+  - value: 0x080B
+    name: 'Nanoleaf Canada Limited'
+
+  - value: 0x080A
+    name: 'Altaneos'
+
+  - value: 0x0809
+    name: 'Trulli Audio'
+
+  - value: 0x0808
+    name: 'SISTEMAS KERN, SOCIEDAD ANÓMINA'
+
+  - value: 0x0807
+    name: 'ECD Electronic Components GmbH Dresden'
+
+  - value: 0x0806
+    name: 'TYRI Sweden AB'
+
+  - value: 0x0805
+    name: 'Urbanminded Ltd'
+
+  - value: 0x0804
+    name: 'Andon Health Co.,Ltd'
+
+  - value: 0x0803
+    name: 'Domintell s.a.'
+
+  - value: 0x0802
+    name: 'NantSound, Inc.'
+
+  - value: 0x0801
+    name: 'CRONUS ELECTRONICS LTD'
+
+  - value: 0x0800
+    name: 'Optek'
+
+  - value: 0x07FF
+    name: 'maxon motor ltd.'
+
+  - value: 0x07FE
+    name: 'BIROTA'
+
+  - value: 0x07FD
+    name: 'JSK CO., LTD.'
+
+  - value: 0x07FC
+    name: 'Renault SA'
+
+  - value: 0x07FB
+    name: 'Access Co., Ltd'
+
+  - value: 0x07FA
+    name: 'Klipsch Group, Inc.'
+
+  - value: 0x07F9
+    name: 'Direct Communication Solutions, Inc.'
+
+  - value: 0x07F8
+    name: 'quip NYC Inc.'
+
+  - value: 0x07F7
+    name: 'Cesar Systems Ltd.'
+
+  - value: 0x07F6
+    name: 'Shenzhen TonliScience and Technology Development Co.,Ltd'
+
+  - value: 0x07F5
+    name: 'Byton North America Corporation'
+
+  - value: 0x07F4
+    name: 'MEDIRLAB Orvosbiologiai Fejleszto Korlatolt Felelossegu Tarsasag'
+
+  - value: 0x07F3
+    name: 'DIGISINE ENERGYTECH CO. LTD.'
+
+  - value: 0x07F2
+    name: 'SERENE GROUP, INC'
+
+  - value: 0x07F1
+    name: 'Zimi Innovations Pty Ltd'
+
+  - value: 0x07F0
+    name: 'e-moola.com Pty Ltd'
+
+  - value: 0x07EF
+    name: 'Aktiebolaget Sandvik Coromant'
+
+  - value: 0x07EE
+    name: 'KidzTek LLC'
+
+  - value: 0x07ED
+    name: 'Joule IQ, INC.'
+
+  - value: 0x07EC
+    name: 'Frecce LLC'
+
+  - value: 0x07EB
+    name: 'NOVABASE S.R.L.'
+
+  - value: 0x07EA
+    name: 'ShapeLog, Inc.'
+
+  - value: 0x07E9
+    name: 'Häfele GmbH & Co KG'
+
+  - value: 0x07E8
+    name: 'Packetcraft, Inc.'
+
+  - value: 0x07E7
+    name: 'Komfort IQ, Inc.'
+
+  - value: 0x07E6
+    name: 'Waybeyond Limited'
+
+  - value: 0x07E5
+    name: 'Minut, Inc.'
+
+  - value: 0x07E4
+    name: 'Geeksme S.L.'
+
+  - value: 0x07E3
+    name: 'Airoha Technology Corp.'
+
+  - value: 0x07E2
+    name: 'Alfred Kaercher SE & Co. KG'
+
+  - value: 0x07E1
+    name: 'Lucie Labs'
+
+  - value: 0x07E0
+    name: 'Edifier International Limited'
+
+  - value: 0x07DF
+    name: 'Snap-on Incorporated'
+
+  - value: 0x07DE
+    name: 'Unlimited Engineering SL'
+
+  - value: 0x07DD
+    name: 'Linear Circuits'
+
+  - value: 0x07DC
+    name: 'ThingOS GmbH & Co KG'
+
+  - value: 0x07DB
+    name: 'Remedee Labs'
+
+  - value: 0x07DA
+    name: 'STARLITE Co., Ltd.'
+
+  - value: 0x07D9
+    name: 'Micro-Design, Inc.'
+
+  - value: 0x07D8
+    name: 'SOLUTIONS AMBRA INC.'
+
+  - value: 0x07D7
+    name: 'Nanjing Qinheng Microelectronics Co., Ltd'
+
+  - value: 0x07D6
+    name: 'ecobee Inc.'
+
+  - value: 0x07D5
+    name: 'hoots classic GmbH'
+
+  - value: 0x07D4
+    name: 'Kano Computing Limited'
+
+  - value: 0x07D3
+    name: 'LIVNEX Co.,Ltd.'
+
+  - value: 0x07D2
+    name: 'React Accessibility Limited'
+
+  - value: 0x07D1
+    name: 'Shanghai Panchip Microelectronics Co., Ltd'
+
+  - value: 0x07D0
+    name: 'Hangzhou Tuya Information  Technology Co., Ltd'
+
+  - value: 0x07CF
+    name: 'NeoSensory, Inc.'
+
+  - value: 0x07CE
+    name: 'Shanghai Top-Chip Microelectronics Tech. Co., LTD'
+
+  - value: 0x07CD
+    name: 'Smart Wave Technologies Canada Inc'
+
+  - value: 0x07CC
+    name: 'Barnacle Systems Inc.'
+
+  - value: 0x07CB
+    name: 'West Pharmaceutical Services, Inc.'
+
+  - value: 0x07CA
+    name: 'Modul-System HH AB'
+
+  - value: 0x07C9
+    name: 'Skullcandy, Inc.'
+
+  - value: 0x07C8
+    name: 'WRLDS Creations AB'
+
+  - value: 0x07C7
+    name: 'iaconicDesign Inc.'
+
+  - value: 0x07C6
+    name: 'Bluenetics GmbH'
+
+  - value: 0x07C5
+    name: 'June Life, Inc.'
+
+  - value: 0x07C4
+    name: 'Johnson Health Tech NA'
+
+  - value: 0x07C3
+    name: 'CIMTechniques, Inc.'
+
+  - value: 0x07C2
+    name: 'Radinn AB'
+
+  - value: 0x07C1
+    name: 'A.W. Chesterton Company'
+
+  - value: 0x07C0
+    name: 'Biral AG'
+
+  - value: 0x07BF
+    name: 'REGULA Ltd.'
+
+  - value: 0x07BE
+    name: 'Axentia Technologies AB'
+
+  - value: 0x07BD
+    name: 'Genedrive Diagnostics Ltd'
+
+  - value: 0x07BC
+    name: 'KD CIRCUITS LLC'
+
+  - value: 0x07BB
+    name: 'EPIC S.R.L.'
+
+  - value: 0x07BA
+    name: 'Battery-Biz Inc.'
+
+  - value: 0x07B9
+    name: 'Epona Biotec Limited'
+
+  - value: 0x07B8
+    name: 'iSwip'
+
+  - value: 0x07B7
+    name: 'ETABLISSEMENTS GEORGES RENAULT'
+
+  - value: 0x07B6
+    name: 'Soundbrenner Limited'
+
+  - value: 0x07B5
+    name: 'CRONO CHIP, S.L.'
+
+  - value: 0x07B4
+    name: 'Hormann KG Antriebstechnik'
+
+  - value: 0x07B3
+    name: '2N TELEKOMUNIKACE a.s.'
+
+  - value: 0x07B2
+    name: 'Moeco IOT Inc.'
+
+  - value: 0x07B1
+    name: 'Thomas Dynamics, LLC'
+
+  - value: 0x07B0
+    name: 'GV Concepts Inc.'
+
+  - value: 0x07AF
+    name: 'Hong Kong Bouffalo Lab Limited'
+
+  - value: 0x07AE
+    name: 'Aurea Solucoes Tecnologicas Ltda.'
+
+  - value: 0x07AD
+    name: 'New H3C Technologies Co.,Ltd'
+
+  - value: 0x07AC
+    name: 'LoupeDeck Oy'
+
+  - value: 0x07AB
+    name: 'Granite River Solutions, Inc.'
+
+  - value: 0x07AA
+    name: 'The Kroger Co.'
+
+  - value: 0x07A9
+    name: 'Bruel & Kjaer Sound & Vibration'
+
+  - value: 0x07A8
+    name: 'conbee GmbH'
+
+  - value: 0x07A7
+    name: 'Zume, Inc.'
+
+  - value: 0x07A6
+    name: 'Musen Connect, Inc.'
+
+  - value: 0x07A5
+    name: 'RAB Lighting, Inc.'
+
+  - value: 0x07A4
+    name: 'Xiamen Mage Information Technology Co., Ltd.'
+
+  - value: 0x07A3
+    name: 'Comcast Cable'
+
+  - value: 0x07A2
+    name: 'Roku, Inc.'
+
+  - value: 0x07A1
+    name: 'Apollo Neuroscience, Inc.'
+
+  - value: 0x07A0
+    name: 'Regent Beleuchtungskorper AG'
+
+  - value: 0x079F
+    name: 'Pune Scientific LLP'
+
+  - value: 0x079E
+    name: 'Smartloxx GmbH'
+
+  - value: 0x079D
+    name: 'Digibale Pty Ltd'
+
+  - value: 0x079C
+    name: 'Sky UK Limited'
+
+  - value: 0x079B
+    name: 'CST ELECTRONICS (PROPRIETARY) LIMITED'
+
+  - value: 0x079A
+    name: 'GuangDong Oppo Mobile Telecommunications Corp., Ltd.'
+
+  - value: 0x0799
+    name: 'PlantChoir Inc.'
+
+  - value: 0x0798
+    name: 'HoloKit, Inc.'
+
+  - value: 0x0797
+    name: 'Water-i.d. GmbH'
+
+  - value: 0x0796
+    name: 'StarLeaf Ltd'
+
+  - value: 0x0795
+    name: 'GASTEC CORPORATION'
+
+  - value: 0x0794
+    name: 'The Coca-Cola Company'
+
+  - value: 0x0793
+    name: 'AEV spol. s r.o.'
+
+  - value: 0x0792
+    name: 'Cricut, Inc.'
+
+  - value: 0x0791
+    name: 'Scosche Industries, Inc.'
+
+  - value: 0x0790
+    name: 'KOMPAN A/S'
+
+  - value: 0x078F
+    name: 'Hanna Instruments, Inc.'
+
+  - value: 0x078E
+    name: 'FUJIMIC NIIGATA, INC.'
+
+  - value: 0x078D
+    name: 'Cybex GmbH'
+
+  - value: 0x078C
+    name: 'MINIBREW HOLDING B.V'
+
+  - value: 0x078B
+    name: 'Optikam Tech Inc.'
+
+  - value: 0x078A
+    name: 'The Wildflower Foundation'
+
+  - value: 0x0789
+    name: 'PCB Piezotronics, Inc.'
+
+  - value: 0x0788
+    name: 'BubblyNet, LLC'
+
+  - value: 0x0787
+    name: 'Pangaea Solution'
+
+  - value: 0x0786
+    name: 'HLP Controls Pty Limited'
+
+  - value: 0x0785
+    name: 'O2 Micro, Inc.'
+
+  - value: 0x0784
+    name: 'audifon GmbH & Co. KG'
+
+  - value: 0x0783
+    name: 'ESEMBER LIMITED LIABILITY COMPANY'
+
+  - value: 0x0782
+    name: 'DeviceDrive AS'
+
+  - value: 0x0781
+    name: 'Qingping Technology (Beijing) Co., Ltd.'
+
+  - value: 0x0780
+    name: 'Finch Technologies Ltd.'
+
+  - value: 0x077F
+    name: 'Glenview Software Corporation'
+
+  - value: 0x077E
+    name: 'Sparkage Inc.'
+
+  - value: 0x077D
+    name: 'Sensority, s.r.o.'
+
+  - value: 0x077C
+    name: 'radius co., ltd.'
+
+  - value: 0x077B
+    name: 'AmaterZ, Inc.'
+
+  - value: 0x077A
+    name: 'Niruha Systems Private Limited'
+
+  - value: 0x0779
+    name: 'Loopshore Oy'
+
+  - value: 0x0778
+    name: 'KOAMTAC INC.'
+
+  - value: 0x0777
+    name: 'Cue'
+
+  - value: 0x0776
+    name: 'Cyber Transport Control GmbH'
+
+  - value: 0x0775
+    name: '4eBusiness GmbH'
+
+  - value: 0x0774
+    name: 'C-MAX Asia Limited'
+
+  - value: 0x0773
+    name: 'Echoflex Solutions Inc.'
+
+  - value: 0x0772
+    name: 'Thirdwayv Inc.'
+
+  - value: 0x0771
+    name: 'Corvex Connected Safety'
+
+  - value: 0x0770
+    name: 'InnoCon Medical ApS'
+
+  - value: 0x076F
+    name: 'Successful Endeavours Pty Ltd'
+
+  - value: 0x076E
+    name: 'WuQi technologies, Inc.'
+
+  - value: 0x076D
+    name: 'Graesslin GmbH'
+
+  - value: 0x076C
+    name: 'Noodle Technology inc'
+
+  - value: 0x076B
+    name: 'Engineered Medical Technologies'
+
+  - value: 0x076A
+    name: 'Dmac Mobile Developments, LLC'
+
+  - value: 0x0769
+    name: 'Force Impact Technologies'
+
+  - value: 0x0768
+    name: 'Peloton Interactive Inc.'
+
+  - value: 0x0767
+    name: 'NITTO DENKO ASIA TECHNICAL CENTRE PTE. LTD.'
+
+  - value: 0x0766
+    name: 'ART AND PROGRAM, INC.'
+
+  - value: 0x0765
+    name: 'Voxx International'
+
+  - value: 0x0764
+    name: 'WWZN Information Technology Company Limited'
+
+  - value: 0x0763
+    name: 'PIKOLIN S.L.'
+
+  - value: 0x0762
+    name: 'TerOpta Ltd'
+
+  - value: 0x0761
+    name: 'Mantis Tech LLC'
+
+  - value: 0x0760
+    name: 'Vimar SpA'
+
+  - value: 0x075F
+    name: 'Remote Solution Co., LTD.'
+
+  - value: 0x075E
+    name: 'Katerra Inc.'
+
+  - value: 0x075D
+    name: 'RHOMBUS SYSTEMS, INC.'
+
+  - value: 0x075C
+    name: 'Antitronics Inc.'
+
+  - value: 0x075B
+    name: 'Smart Sensor Devices AB'
+
+  - value: 0x075A
+    name: 'HARMAN CO.,LTD.'
+
+  - value: 0x0759
+    name: 'Shanghai InGeek Cyber Security Co., Ltd.'
+
+  - value: 0x0758
+    name: 'umanSense AB'
+
+  - value: 0x0757
+    name: 'ELA Innovation'
+
+  - value: 0x0756
+    name: 'Lumens For Less, Inc'
+
+  - value: 0x0755
+    name: 'Brother Industries, Ltd'
+
+  - value: 0x0754
+    name: 'Michael Parkin'
+
+  - value: 0x0753
+    name: 'JLG Industries, Inc.'
+
+  - value: 0x0752
+    name: 'Elatec GmbH'
+
+  - value: 0x0751
+    name: 'Changsha JEMO IC Design Co.,Ltd'
+
+  - value: 0x0750
+    name: 'Hamilton Professional Services of Canada Incorporated'
+
+  - value: 0x074F
+    name: 'MEDIATECH S.R.L.'
+
+  - value: 0x074E
+    name: 'EAGLE DETECTION SA'
+
+  - value: 0x074D
+    name: 'Amtech Systems, LLC'
+
+  - value: 0x074C
+    name: 'iopool s.a.'
+
+  - value: 0x074B
+    name: 'Sarvavid Software Solutions LLP'
+
+  - value: 0x074A
+    name: 'Illusory Studios LLC'
+
+  - value: 0x0749
+    name: 'DIAODIAO (Beijing) Technology Co., Ltd.'
+
+  - value: 0x0748
+    name: 'GuangZhou KuGou Computer Technology Co.Ltd'
+
+  - value: 0x0747
+    name: 'OR Technologies Pty Ltd'
+
+  - value: 0x0746
+    name: 'Seitec Elektronik GmbH'
+
+  - value: 0x0745
+    name: 'WIZNOVA, Inc.'
+
+  - value: 0x0744
+    name: 'SOCOMEC'
+
+  - value: 0x0743
+    name: 'Sanofi'
+
+  - value: 0x0742
+    name: 'DML LLC'
+
+  - value: 0x0741
+    name: 'MAC SRL'
+
+  - value: 0x0740
+    name: 'HITIQ LIMITED'
+
+  - value: 0x073F
+    name: 'Beijing Unisoc Technologies Co., Ltd.'
+
+  - value: 0x073E
+    name: 'Bluepack S.R.L.'
+
+  - value: 0x073D
+    name: 'Beijing Hao Heng Tian Tech Co., Ltd.'
+
+  - value: 0x073C
+    name: 'Acubit ApS'
+
+  - value: 0x073B
+    name: 'Fantini Cosmi s.p.a.'
+
+  - value: 0x073A
+    name: 'Chandler Systems Inc.'
+
+  - value: 0x0739
+    name: 'Jiangsu Qinheng Co., Ltd.'
+
+  - value: 0x0738
+    name: 'Glass Security Pte Ltd'
+
+  - value: 0x0737
+    name: 'LLC Navitek'
+
+  - value: 0x0736
+    name: 'Luna XIO, Inc.'
+
+  - value: 0x0735
+    name: 'UpRight Technologies LTD'
+
+  - value: 0x0734
+    name: 'DiUS Computing Pty Ltd'
+
+  - value: 0x0733
+    name: 'Iguanavation, Inc.'
+
+  - value: 0x0732
+    name: 'Dairy Tech, LLC'
+
+  - value: 0x0731
+    name: 'ABLIC Inc.'
+
+  - value: 0x0730
+    name: 'Wildlife Acoustics, Inc.'
+
+  - value: 0x072F
+    name: 'OnePlus Electronics (Shenzhen) Co., Ltd.'
+
+  - value: 0x072E
+    name: 'Open Platform Systems LLC'
+
+  - value: 0x072D
+    name: 'Safera Oy'
+
+  - value: 0x072C
+    name: 'GWA Hygiene GmbH'
+
+  - value: 0x072B
+    name: 'Bitkey Inc.'
+
+  - value: 0x072A
+    name: 'JMR embedded systems GmbH'
+
+  - value: 0x0729
+    name: 'SwaraLink Technologies'
+
+  - value: 0x0728
+    name: 'Eli Lilly and Company'
+
+  - value: 0x0727
+    name: 'STALKIT AS'
+
+  - value: 0x0726
+    name: 'PHC Corporation'
+
+  - value: 0x0725
+    name: 'Tedee Sp. z o.o.'
+
+  - value: 0x0724
+    name: 'Guangzhou SuperSound Information Technology Co.,Ltd'
+
+  - value: 0x0723
+    name: 'Ford Motor Company'
+
+  - value: 0x0722
+    name: 'Xiamen Eholder Electronics Co.Ltd'
+
+  - value: 0x0721
+    name: 'Clover Network, Inc.'
+
+  - value: 0x0720
+    name: 'Oculeve, Inc.'
+
+  - value: 0x071F
+    name: 'Dongguan Liesheng Electronic Co.Ltd'
+
+  - value: 0x071E
+    name: 'DONGGUAN HELE ELECTRONICS CO., LTD'
+
+  - value: 0x071D
+    name: 'exoTIC Systems'
+
+  - value: 0x071C
+    name: 'F5 Sports, Inc'
+
+  - value: 0x071B
+    name: 'Precor'
+
+  - value: 0x071A
+    name: 'REVSMART WEARABLE HK CO LTD'
+
+  - value: 0x0719
+    name: 'COREIOT PTY LTD'
+
+  - value: 0x0718
+    name: 'IDIBAIX enginneering'
+
+  - value: 0x0717
+    name: 'iQsquare BV'
+
+  - value: 0x0716
+    name: 'Altonics'
+
+  - value: 0x0715
+    name: 'MBARC LABS Inc'
+
+  - value: 0x0714
+    name: 'MindPeace Safety LLC'
+
+  - value: 0x0713
+    name: 'Respiri Limited'
+
+  - value: 0x0712
+    name: 'Bull Group Company Limited'
+
+  - value: 0x0711
+    name: 'ABAX AS'
+
+  - value: 0x0710
+    name: 'Audiodo AB'
+
+  - value: 0x070F
+    name: 'California Things Inc.'
+
+  - value: 0x070E
+    name: 'FiveCo Sarl'
+
+  - value: 0x070D
+    name: 'SmartSnugg Pty Ltd'
+
+  - value: 0x070C
+    name: 'Beijing Winner Microelectronics Co.,Ltd'
+
+  - value: 0x070B
+    name: 'Element Products, Inc.'
+
+  - value: 0x070A
+    name: 'Huf Hülsbeck & Fürst GmbH & Co. KG'
+
+  - value: 0x0709
+    name: 'Carewear Corp.'
+
+  - value: 0x0708
+    name: 'Be Interactive Co., Ltd'
+
+  - value: 0x0707
+    name: 'Essity Hygiene and Health Aktiebolag'
+
+  - value: 0x0706
+    name: 'Wernher von Braun Center for ASdvanced Research'
+
+  - value: 0x0705
+    name: 'AB Electrolux'
+
+  - value: 0x0704
+    name: 'JBX Designs Inc.'
+
+  - value: 0x0703
+    name: 'Beijing Jingdong Century Trading Co., Ltd.'
+
+  - value: 0x0702
+    name: 'Akciju sabiedriba "SAF TEHNIKA"'
+
+  - value: 0x0701
+    name: 'PAFERS TECH'
+
+  - value: 0x0700
+    name: 'TraqFreq LLC'
+
+  - value: 0x06FF
+    name: 'Redpine Signals Inc'
+
+  - value: 0x06FE
+    name: 'Mahr GmbH'
+
+  - value: 0x06FD
+    name: 'ESS Embedded System Solutions Inc.'
+
+  - value: 0x06FC
+    name: 'Tom Communication Industrial Co.,Ltd.'
+
+  - value: 0x06FB
+    name: 'Sartorius AG'
+
+  - value: 0x06FA
+    name: 'Enequi AB'
+
+  - value: 0x06F9
+    name: 'happybrush GmbH'
+
+  - value: 0x06F8
+    name: 'BodyPlus Technology Co.,Ltd'
+
+  - value: 0x06F7
+    name: 'WILKA Schliesstechnik GmbH'
+
+  - value: 0x06F6
+    name: 'Vitulo Plus BV'
+
+  - value: 0x06F5
+    name: 'Vigil Technologies Inc.'
+
+  - value: 0x06F4
+    name: 'Touché Technology Ltd'
+
+  - value: 0x06F3
+    name: 'Alfred International Inc.'
+
+  - value: 0x06F2
+    name: 'Trapper Data AB'
+
+  - value: 0x06F1
+    name: 'Shibutani Co., Ltd.'
+
+  - value: 0x06F0
+    name: 'Chargy Technologies, SL'
+
+  - value: 0x06EF
+    name: 'ALCARE Co., Ltd.'
+
+  - value: 0x06EE
+    name: 'Avantis Systems Limited'
+
+  - value: 0x06ED
+    name: 'J Neades Ltd'
+
+  - value: 0x06EC
+    name: 'Sigur'
+
+  - value: 0x06EB
+    name: 'Houston Radar LLC'
+
+  - value: 0x06EA
+    name: 'SafeLine Sweden AB'
+
+  - value: 0x06E9
+    name: 'Zmartfun Electronics, Inc.'
+
+  - value: 0x06E8
+    name: 'Almendo Technologies GmbH'
+
+  - value: 0x06E7
+    name: 'VELUX A/S'
+
+  - value: 0x06E6
+    name: 'NIHON DENGYO KOUSAKU'
+
+  - value: 0x06E5
+    name: 'OPTEX CO.,LTD.'
+
+  - value: 0x06E4
+    name: 'Aluna'
+
+  - value: 0x06E3
+    name: 'Spinlock Ltd'
+
+  - value: 0x06E2
+    name: 'Alango Technologies Ltd'
+
+  - value: 0x06E1
+    name: 'Milestone AV Technologies LLC'
+
+  - value: 0x06E0
+    name: 'Avaya Inc.'
+
+  - value: 0x06DF
+    name: 'HLI Solutions Inc.'
+
+  - value: 0x06DE
+    name: 'Navcast, Inc.'
+
+  - value: 0x06DD
+    name: 'Intellithings Ltd.'
+
+  - value: 0x06DC
+    name: 'Industrial Network Controls, LLC'
+
+  - value: 0x06DB
+    name: 'Automatic Labs, Inc.'
+
+  - value: 0x06DA
+    name: 'Zliide Technologies ApS'
+
+  - value: 0x06D9
+    name: 'Shanghai Mountain View Silicon Co.,Ltd.'
+
+  - value: 0x06D8
+    name: 'AW Company'
+
+  - value: 0x06D7
+    name: 'FUBA Automotive Electronics GmbH'
+
+  - value: 0x06D6
+    name: 'JCT Healthcare Pty Ltd'
+
+  - value: 0x06D5
+    name: 'Sensirion AG'
+
+  - value: 0x06D4
+    name: 'DYNAKODE TECHNOLOGY PRIVATE LIMITED'
+
+  - value: 0x06D3
+    name: 'TriTeq Lock and Security, LLC'
+
+  - value: 0x06D2
+    name: 'CeoTronics AG'
+
+  - value: 0x06D1
+    name: 'Meyer Sound Laboratories, Incorporated'
+
+  - value: 0x06D0
+    name: 'Etekcity Corporation'
+
+  - value: 0x06CF
+    name: 'Belparts N.V.'
+
+  - value: 0x06CE
+    name: 'FIOR & GENTZ'
+
+  - value: 0x06CD
+    name: 'DIG Corporation'
+
+  - value: 0x06CC
+    name: 'Dongguan SmartAction Technology Co.,Ltd.'
+
+  - value: 0x06CB
+    name: 'Dyeware, LLC'
+
+  - value: 0x06CA
+    name: 'Shenzhen Zhongguang Infotech Technology Development Co., Ltd'
+
+  - value: 0x06C9
+    name: 'MYLAPS B.V.'
+
+  - value: 0x06C8
+    name: 'Storz & Bickel GmbH & Co. KG'
+
+  - value: 0x06C7
+    name: 'Somatix Inc'
+
+  - value: 0x06C6
+    name: 'Simm Tronic Limited'
+
+  - value: 0x06C5
+    name: 'Urban Compass, Inc'
+
+  - value: 0x06C4
+    name: 'Dream Labs GmbH'
+
+  - value: 0x06C3
+    name: 'King I Electronics.Co.,Ltd'
+
+  - value: 0x06C2
+    name: 'Measurlogic Inc.'
+
+  - value: 0x06C1
+    name: 'Alarm.com Holdings, Inc'
+
+  - value: 0x06C0
+    name: 'CAME S.p.A.'
+
+  - value: 0x06BF
+    name: 'Delcom Products Inc.'
+
+  - value: 0x06BE
+    name: 'HitSeed Oy'
+
+  - value: 0x06BD
+    name: 'ABB Oy'
+
+  - value: 0x06BC
+    name: 'TWS Srl'
+
+  - value: 0x06BB
+    name: 'Leaftronix Analogic Solutions Private Limited'
+
+  - value: 0x06BA
+    name: 'Beaconzone Ltd'
+
+  - value: 0x06B9
+    name: 'Beflex Inc.'
+
+  - value: 0x06B8
+    name: 'ShadeCraft, Inc'
+
+  - value: 0x06B7
+    name: 'iCOGNIZE GmbH'
+
+  - value: 0x06B6
+    name: 'Sociometric Solutions, Inc.'
+
+  - value: 0x06B5
+    name: 'Wabilogic Ltd.'
+
+  - value: 0x06B4
+    name: 'Sencilion Oy'
+
+  - value: 0x06B3
+    name: 'The Hablab ApS'
+
+  - value: 0x06B2
+    name: 'Tussock Innovation 2013 Limited'
+
+  - value: 0x06B1
+    name: 'SimpliSafe, Inc.'
+
+  - value: 0x06B0
+    name: 'BRK Brands, Inc.'
+
+  - value: 0x06AF
+    name: 'Shoof Technologies'
+
+  - value: 0x06AE
+    name: 'SenseQ Inc.'
+
+  - value: 0x06AD
+    name: 'InnovaSea Systems Inc.'
+
+  - value: 0x06AC
+    name: 'Ingchips Technology Co., Ltd.'
+
+  - value: 0x06AB
+    name: 'HMS Industrial Networks AB'
+
+  - value: 0x06AA
+    name: 'Produal Oy'
+
+  - value: 0x06A9
+    name: 'Soundmax Electronics Limited'
+
+  - value: 0x06A8
+    name: 'GD Midea Air-Conditioning Equipment Co., Ltd.'
+
+  - value: 0x06A7
+    name: 'Chipsea Technologies (ShenZhen) Corp.'
+
+  - value: 0x06A6
+    name: 'Roambee Corporation'
+
+  - value: 0x06A5
+    name: 'TEKZITEL PTY LTD'
+
+  - value: 0x06A4
+    name: 'LIMNO Co. Ltd.'
+
+  - value: 0x06A3
+    name: 'Nymbus, LLC'
+
+  - value: 0x06A2
+    name: 'Globalworx GmbH'
+
+  - value: 0x06A1
+    name: 'Cardo Systems, Ltd'
+
+  - value: 0x06A0
+    name: 'OBIQ Location Technology Inc.'
+
+  - value: 0x069F
+    name: 'FlowMotion Technologies AS'
+
+  - value: 0x069E
+    name: 'Delta Electronics, Inc.'
+
+  - value: 0x069D
+    name: 'Vakaros LLC'
+
+  - value: 0x069C
+    name: 'Noomi AB'
+
+  - value: 0x069B
+    name: 'Dragonchip Limited'
+
+  - value: 0x069A
+    name: 'Adero, Inc.'
+
+  - value: 0x0699
+    name: 'RandomLab SAS'
+
+  - value: 0x0698
+    name: 'Wood IT Security, LLC'
+
+  - value: 0x0697
+    name: 'Stemco Products Inc'
+
+  - value: 0x0696
+    name: 'Gunakar Private Limited'
+
+  - value: 0x0695
+    name: 'Koki Holdings Co., Ltd.'
+
+  - value: 0x0694
+    name: 'T&A Laboratories LLC'
+
+  - value: 0x0693
+    name: 'Hach - Danaher'
+
+  - value: 0x0692
+    name: 'Georg Fischer AG'
+
+  - value: 0x0691
+    name: 'Curie Point AB'
+
+  - value: 0x0690
+    name: 'Eccrine Systems, Inc.'
+
+  - value: 0x068F
+    name: 'JRM Group Limited'
+
+  - value: 0x068E
+    name: 'Razer Inc.'
+
+  - value: 0x068D
+    name: 'JetBeep Inc.'
+
+  - value: 0x068C
+    name: 'Changzhou Sound Dragon Electronics and Acoustics Co., Ltd'
+
+  - value: 0x068B
+    name: 'Jiangsu Teranovo Tech Co., Ltd.'
+
+  - value: 0x068A
+    name: 'Raytac Corporation'
+
+  - value: 0x0689
+    name: 'Tacx b.v.'
+
+  - value: 0x0688
+    name: 'Amsted Digital Solutions Inc.'
+
+  - value: 0x0687
+    name: 'Cherry GmbH'
+
+  - value: 0x0686
+    name: 'inQs Co., Ltd.'
+
+  - value: 0x0685
+    name: 'Greenwald Industries'
+
+  - value: 0x0684
+    name: 'Dermalapps, LLC'
+
+  - value: 0x0683
+    name: 'Eltako GmbH'
+
+  - value: 0x0682
+    name: 'Photron Limited'
+
+  - value: 0x0681
+    name: 'Trade FIDES a.s.'
+
+  - value: 0x0680
+    name: 'Mannkind Corporation'
+
+  - value: 0x067F
+    name: 'NETGRID S.N.C. DI BISSOLI MATTEO, CAMPOREALE SIMONE, TOGNETTI FEDERICO'
+
+  - value: 0x067E
+    name: 'MbientLab Inc'
+
+  - value: 0x067D
+    name: 'Form Athletica Inc.'
+
+  - value: 0x067C
+    name: 'Tile, Inc.'
+
+  - value: 0x067B
+    name: 'I.FARM, INC.'
+
+  - value: 0x067A
+    name: 'The Energy Conservatory, Inc.'
+
+  - value: 0x0679
+    name: '4iiii Innovations Inc.'
+
+  - value: 0x0678
+    name: 'SABIK Offshore GmbH'
+
+  - value: 0x0677
+    name: 'Innovation First, Inc.'
+
+  - value: 0x0676
+    name: 'Expai Solutions Private Limited'
+
+  - value: 0x0675
+    name: 'Deco Enterprises, Inc.'
+
+  - value: 0x0674
+    name: 'BeSpoon'
+
+  - value: 0x0673
+    name: 'Innova Ideas Limited'
+
+  - value: 0x0672
+    name: 'Kopi'
+
+  - value: 0x0671
+    name: 'Buzz Products Ltd.'
+
+  - value: 0x0670
+    name: 'Gema Switzerland GmbH'
+
+  - value: 0x066F
+    name: 'Hug Technology Ltd'
+
+  - value: 0x066E
+    name: 'Eurotronik Kranj d.o.o.'
+
+  - value: 0x066D
+    name: 'Venso EcoSolutions AB'
+
+  - value: 0x066C
+    name: 'Ztove ApS'
+
+  - value: 0x066B
+    name: 'DewertOkin GmbH'
+
+  - value: 0x066A
+    name: 'Brady Worldwide Inc.'
+
+  - value: 0x0669
+    name: 'Livanova USA, Inc.'
+
+  - value: 0x0668
+    name: 'Bleb Technology srl'
+
+  - value: 0x0667
+    name: 'Spark Technology Labs Inc.'
+
+  - value: 0x0666
+    name: 'WTO Werkzeug-Einrichtungen GmbH'
+
+  - value: 0x0665
+    name: 'Pure International Limited'
+
+  - value: 0x0664
+    name: 'RHA TECHNOLOGIES LTD'
+
+  - value: 0x0663
+    name: 'Advanced Telemetry Systems, Inc.'
+
+  - value: 0x0662
+    name: 'Particle Industries, Inc.'
+
+  - value: 0x0661
+    name: 'Mode Lighting Limited'
+
+  - value: 0x0660
+    name: 'RTC Industries, Inc.'
+
+  - value: 0x065F
+    name: 'Ricoh Company Ltd'
+
+  - value: 0x065E
+    name: 'Alo AB'
+
+  - value: 0x065D
+    name: 'Panduit Corp.'
+
+  - value: 0x065C
+    name: 'PixArt Imaging Inc.'
+
+  - value: 0x065B
+    name: 'Sesam Solutions BV'
+
+  - value: 0x065A
+    name: 'Zound Industries International AB'
+
+  - value: 0x0659
+    name: 'UnSeen Technologies Oy'
+
+  - value: 0x0658
+    name: 'Payex Norge AS'
+
+  - value: 0x0657
+    name: 'Meshtronix Limited'
+
+  - value: 0x0656
+    name: 'ZhuHai AdvanPro Technology Company Limited'
+
+  - value: 0x0655
+    name: 'Renishaw PLC'
+
+  - value: 0x0654
+    name: 'Ledlenser GmbH & Co. KG'
+
+  - value: 0x0653
+    name: 'Meggitt SA'
+
+  - value: 0x0652
+    name: 'ITZ Innovations- und Technologiezentrum GmbH'
+
+  - value: 0x0651
+    name: 'Stasis Labs, Inc.'
+
+  - value: 0x0650
+    name: 'Coravin, Inc.'
+
+  - value: 0x064F
+    name: 'Digital Matter Pty Ltd'
+
+  - value: 0x064E
+    name: 'KRUXWorks Technologies Private Limited'
+
+  - value: 0x064D
+    name: 'iLOQ Oy'
+
+  - value: 0x064C
+    name: 'Zumtobel Group AG'
+
+  - value: 0x064B
+    name: 'Scale-Tec, Ltd'
+
+  - value: 0x064A
+    name: 'Open Research Institute, Inc.'
+
+  - value: 0x0649
+    name: 'Ryeex Technology Co.,Ltd.'
+
+  - value: 0x0648
+    name: 'Ultune Technologies'
+
+  - value: 0x0647
+    name: 'MED-EL'
+
+  - value: 0x0646
+    name: 'SGV Group Holding GmbH & Co. KG'
+
+  - value: 0x0645
+    name: 'BM3'
+
+  - value: 0x0644
+    name: 'Apogee Instruments'
+
+  - value: 0x0643
+    name: 'makita corporation'
+
+  - value: 0x0642
+    name: 'Bluetrum Technology Co.,Ltd'
+
+  - value: 0x0641
+    name: 'Revenue Collection Systems FRANCE SAS'
+
+  - value: 0x0640
+    name: 'Dish Network LLC'
+
+  - value: 0x063F
+    name: 'LDL TECHNOLOGY'
+
+  - value: 0x063E
+    name: 'The Indoor Lab, LLC'
+
+  - value: 0x063D
+    name: 'Xradio Technology Co.,Ltd.'
+
+  - value: 0x063C
+    name: 'Contec Medical Systems Co., Ltd.'
+
+  - value: 0x063B
+    name: 'Kromek Group Plc'
+
+  - value: 0x063A
+    name: 'Prolojik Limited'
+
+  - value: 0x0639
+    name: 'Shenzhen Minew Technologies Co., Ltd.'
+
+  - value: 0x0638
+    name: 'LX SOLUTIONS PTY LIMITED'
+
+  - value: 0x0637
+    name: 'GiP Innovation Tools GmbH'
+
+  - value: 0x0636
+    name: 'ELECTRONICA INTEGRAL DE SONIDO S.A.'
+
+  - value: 0x0635
+    name: 'Crookwood'
+
+  - value: 0x0634
+    name: 'Fanstel Corp'
+
+  - value: 0x0633
+    name: 'Wangi Lai PLT'
+
+  - value: 0x0632
+    name: 'Hugo Muller GmbH & Co KG'
+
+  - value: 0x0631
+    name: 'Fortiori Design LLC'
+
+  - value: 0x0630
+    name: 'Asthrea D.O.O.'
+
+  - value: 0x062F
+    name: 'ONKYO Corporation'
+
+  - value: 0x062E
+    name: 'Procept'
+
+  - value: 0x062D
+    name: 'Vossloh-Schwabe Deutschland GmbH'
+
+  - value: 0x062C
+    name: 'ASPion GmbH'
+
+  - value: 0x062B
+    name: 'MinebeaMitsumi Inc.'
+
+  - value: 0x062A
+    name: 'Lunatico Astronomia SL'
+
+  - value: 0x0629
+    name: 'PHONEPE PVT LTD'
+
+  - value: 0x0628
+    name: 'Ensto Oy'
+
+  - value: 0x0627
+    name: 'WEG S.A.'
+
+  - value: 0x0626
+    name: 'Amplifico'
+
+  - value: 0x0625
+    name: 'Square Panda, Inc.'
+
+  - value: 0x0624
+    name: 'Biovotion AG'
+
+  - value: 0x0623
+    name: 'Philadelphia Scientific (U.K.) Limited'
+
+  - value: 0x0622
+    name: 'Beam Labs, LLC'
+
+  - value: 0x0621
+    name: 'Noordung d.o.o.'
+
+  - value: 0x0620
+    name: 'Forciot Oy'
+
+  - value: 0x061F
+    name: 'Phrame Inc.'
+
+  - value: 0x061E
+    name: 'Diamond Kinetics, Inc.'
+
+  - value: 0x061D
+    name: 'SENS Innovation ApS'
+
+  - value: 0x061C
+    name: 'Univations Limited'
+
+  - value: 0x061B
+    name: 'silex technology, inc.'
+
+  - value: 0x061A
+    name: 'R.W. Beckett Corporation'
+
+  - value: 0x0619
+    name: 'Six Guys Labs, s.r.o.'
+
+  - value: 0x0618
+    name: 'Audio-Technica Corporation'
+
+  - value: 0x0617
+    name: 'WIZCONNECTED COMPANY LIMITED'
+
+  - value: 0x0616
+    name: 'OS42 UG (haftungsbeschraenkt)'
+
+  - value: 0x0615
+    name: 'INTER ACTION Corporation'
+
+  - value: 0x0614
+    name: 'OnAsset Intelligence, Inc.'
+
+  - value: 0x0613
+    name: 'Hans Dinslage GmbH'
+
+  - value: 0x0612
+    name: 'Playfinity AS'
+
+  - value: 0x0611
+    name: 'Beurer GmbH'
+
+  - value: 0x0610
+    name: 'ADH GUARDIAN USA LLC'
+
+  - value: 0x060F
+    name: 'Signify Netherlands B.V.'
+
+  - value: 0x060E
+    name: 'Blueair AB'
+
+  - value: 0x060D
+    name: 'TDK Corporation'
+
+  - value: 0x060C
+    name: 'Vuzix Corporation'
+
+  - value: 0x060B
+    name: 'Triax Technologies Inc'
+
+  - value: 0x060A
+    name: 'IQAir AG'
+
+  - value: 0x0609
+    name: 'BUCHI Labortechnik AG'
+
+  - value: 0x0608
+    name: 'KeySafe-Cloud'
+
+  - value: 0x0607
+    name: 'Rookery Technology Ltd'
+
+  - value: 0x0606
+    name: 'John Deere'
+
+  - value: 0x0605
+    name: 'FMW electronic Futterer u. Maier-Wolf OHG'
+
+  - value: 0x0604
+    name: 'Cell2Jack LLC'
+
+  - value: 0x0603
+    name: 'Fourth Evolution Inc'
+
+  - value: 0x0602
+    name: 'Geberit International AG'
+
+  - value: 0x0601
+    name: 'Schrader Electronics'
+
+  - value: 0x0600
+    name: 'iRobot Corporation'
+
+  - value: 0x05FF
+    name: 'Wellnomics Ltd'
+
+  - value: 0x05FE
+    name: 'Niko nv'
+
+  - value: 0x05FD
+    name: 'Innoseis'
+
+  - value: 0x05FC
+    name: 'Masbando GmbH'
+
+  - value: 0x05FB
+    name: 'Arblet Inc.'
+
+  - value: 0x05FA
+    name: 'Konami Sports Life Co., Ltd.'
+
+  - value: 0x05F9
+    name: 'Hagleitner Hygiene International GmbH'
+
+  - value: 0x05F8
+    name: 'Anki Inc.'
+
+  - value: 0x05F7
+    name: 'TRACMO, INC.'
+
+  - value: 0x05F6
+    name: 'DPTechnics'
+
+  - value: 0x05F5
+    name: 'GS TAG'
+
+  - value: 0x05F4
+    name: 'Clearity, LLC'
+
+  - value: 0x05F3
+    name: 'SeeScan'
+
+  - value: 0x05F2
+    name: 'Try and E CO.,LTD.'
+
+  - value: 0x05F1
+    name: 'The Linux Foundation'
+
+  - value: 0x05F0
+    name: 'beken'
+
+  - value: 0x05EF
+    name: 'SIKOM AS'
+
+  - value: 0x05EE
+    name: 'Wristcam Inc.'
+
+  - value: 0x05ED
+    name: 'Fuji Xerox Co., Ltd'
+
+  - value: 0x05EC
+    name: 'Gycom Svenska AB'
+
+  - value: 0x05EB
+    name: 'Bayerische Motoren Werke AG'
+
+  - value: 0x05EA
+    name: 'ACS-Control-System GmbH'
+
+  - value: 0x05E9
+    name: 'iconmobile GmbH'
+
+  - value: 0x05E8
+    name: 'COWBOY'
+
+  - value: 0x05E7
+    name: 'PressurePro'
+
+  - value: 0x05E6
+    name: 'Motion Instruments Inc.'
+
+  - value: 0x05E5
+    name: 'INEO ENERGY& SYSTEMS'
+
+  - value: 0x05E4
+    name: 'Taiyo Yuden Co., Ltd'
+
+  - value: 0x05E3
+    name: 'Elemental Machines, Inc.'
+
+  - value: 0x05E2
+    name: 'stAPPtronics GmbH'
+
+  - value: 0x05E1
+    name: 'Human, Incorporated'
+
+  - value: 0x05E0
+    name: 'Viper Design LLC'
+
+  - value: 0x05DF
+    name: 'VIRTUALCLINIC.DIRECT LIMITED'
+
+  - value: 0x05DE
+    name: 'QT Medical INC.'
+
+  - value: 0x05DD
+    name: 'essentim GmbH'
+
+  - value: 0x05DC
+    name: 'Petronics Inc.'
+
+  - value: 0x05DB
+    name: 'Avid Identification Systems, Inc.'
+
+  - value: 0x05DA
+    name: 'Applied Neural Research Corp'
+
+  - value: 0x05D9
+    name: 'Toyo Electronics Corporation'
+
+  - value: 0x05D8
+    name: 'Farm Jenny LLC'
+
+  - value: 0x05D7
+    name: 'modum.io AG'
+
+  - value: 0x05D6
+    name: 'Zhuhai Jieli technology Co.,Ltd'
+
+  - value: 0x05D5
+    name: 'TEGAM, Inc.'
+
+  - value: 0x05D4
+    name: 'LAMPLIGHT Co., Ltd.'
+
+  - value: 0x05D3
+    name: 'Acurable Limited'
+
+  - value: 0x05D2
+    name: 'frogblue TECHNOLOGY GmbH'
+
+  - value: 0x05D1
+    name: 'Lindab AB'
+
+  - value: 0x05D0
+    name: 'Anova Applied Electronics'
+
+  - value: 0x05CF
+    name: 'Biowatch SA'
+
+  - value: 0x05CE
+    name: 'V-ZUG Ltd'
+
+  - value: 0x05CD
+    name: 'RJ Brands LLC'
+
+  - value: 0x05CC
+    name: 'WATTS ELECTRONICS'
+
+  - value: 0x05CB
+    name: 'LucentWear LLC'
+
+  - value: 0x05CA
+    name: 'MHL Custom Inc'
+
+  - value: 0x05C9
+    name: 'TBS Electronics B.V.'
+
+  - value: 0x05C8
+    name: 'SOMFY SAS'
+
+  - value: 0x05C7
+    name: 'Lippert Components, INC'
+
+  - value: 0x05C6
+    name: 'Smart Animal Training Systems, LLC'
+
+  - value: 0x05C5
+    name: 'SELVE GmbH & Co. KG'
+
+  - value: 0x05C4
+    name: 'Codecoup sp. z o.o. sp. k.'
+
+  - value: 0x05C3
+    name: 'Runtime, Inc.'
+
+  - value: 0x05C2
+    name: 'Grote Industries'
+
+  - value: 0x05C1
+    name: 'P.I.Engineering'
+
+  - value: 0x05C0
+    name: 'Nalu Medical, Inc.'
+
+  - value: 0x05BF
+    name: 'Real-World-Systems Corporation'
+
+  - value: 0x05BE
+    name: 'RFID Global by Softwork SrL'
+
+  - value: 0x05BD
+    name: 'ULC Robotics Inc.'
+
+  - value: 0x05BC
+    name: 'Leviton Mfg. Co., Inc.'
+
+  - value: 0x05BB
+    name: 'Oxford Metrics plc'
+
+  - value: 0x05BA
+    name: 'igloohome'
+
+  - value: 0x05B9
+    name: 'Suzhou Pairlink Network Technology'
+
+  - value: 0x05B8
+    name: 'Ambystoma Labs Inc.'
+
+  - value: 0x05B7
+    name: 'Beijing Pinecone Electronics Co.,Ltd.'
+
+  - value: 0x05B6
+    name: 'Elecs Industry Co.,Ltd.'
+
+  - value: 0x05B5
+    name: 'verisilicon'
+
+  - value: 0x05B4
+    name: 'White Horse Scientific ltd'
+
+  - value: 0x05B3
+    name: 'Parabit Systems, Inc.'
+
+  - value: 0x05B2
+    name: 'CAREL INDUSTRIES S.P.A.'
+
+  - value: 0x05B1
+    name: 'Medallion Instrumentation Systems'
+
+  - value: 0x05B0
+    name: 'NewTec GmbH'
+
+  - value: 0x05AF
+    name: 'OV LOOP, INC.'
+
+  - value: 0x05AE
+    name: 'CARMATE MFG.CO.,LTD'
+
+  - value: 0x05AD
+    name: 'INIA'
+
+  - value: 0x05AC
+    name: 'GoerTek Dynaudio Co., Ltd.'
+
+  - value: 0x05AB
+    name: 'Nofence AS'
+
+  - value: 0x05AA
+    name: 'Tramex Limited'
+
+  - value: 0x05A9
+    name: 'Monidor'
+
+  - value: 0x05A8
+    name: 'Tom Allebrandi Consulting'
+
+  - value: 0x05A7
+    name: 'Sonos Inc'
+
+  - value: 0x05A6
+    name: 'Telecon Mobile Limited'
+
+  - value: 0x05A5
+    name: 'Kiiroo BV'
+
+  - value: 0x05A4
+    name: 'O. E. M. Controls, Inc.'
+
+  - value: 0x05A3
+    name: 'Axiomware Systems Incorporated'
+
+  - value: 0x05A2
+    name: 'ADHERIUM(NZ) LIMITED'
+
+  - value: 0x05A1
+    name: 'Shanghai Xiaoyi Technology Co.,Ltd.'
+
+  - value: 0x05A0
+    name: 'Dream Devices Technologies Oy'
+
+  - value: 0x059F
+    name: 'Fisher & Paykel Healthcare'
+
+  - value: 0x059E
+    name: 'Polycom, Inc.'
+
+  - value: 0x059D
+    name: 'Tandem Diabetes Care'
+
+  - value: 0x059C
+    name: 'Macrogiga Electronics'
+
+  - value: 0x059B
+    name: 'Dataflow Systems Limited'
+
+  - value: 0x059A
+    name: 'Teledyne Lecroy, Inc.'
+
+  - value: 0x0599
+    name: 'Lazlo326, LLC.'
+
+  - value: 0x0598
+    name: 'rapitag GmbH'
+
+  - value: 0x0597
+    name: 'RadioPulse Inc'
+
+  - value: 0x0596
+    name: 'My Smart Blinds'
+
+  - value: 0x0595
+    name: 'Inor Process AB'
+
+  - value: 0x0594
+    name: 'Kohler Company'
+
+  - value: 0x0593
+    name: 'Spaulding Clinical Research'
+
+  - value: 0x0592
+    name: 'IZITHERM'
+
+  - value: 0x0591
+    name: 'Viasat Group S.p.A.'
+
+  - value: 0x0590
+    name: 'Pur3 Ltd'
+
+  - value: 0x058F
+    name: 'HENDON SEMICONDUCTORS PTY LTD'
+
+  - value: 0x058E
+    name: 'Meta Platforms Technologies, LLC'
+
+  - value: 0x058D
+    name: 'Jungheinrich Aktiengesellschaft'
+
+  - value: 0x058C
+    name: 'Fracarro Radioindustrie SRL'
+
+  - value: 0x058B
+    name: 'Maxim Integrated Products'
+
+  - value: 0x058A
+    name: 'START TODAY CO.,LTD.'
+
+  - value: 0x0589
+    name: 'Star Technologies'
+
+  - value: 0x0588
+    name: 'ALT-TEKNIK LLC'
+
+  - value: 0x0587
+    name: 'Derichs GmbH'
+
+  - value: 0x0586
+    name: 'LEGRAND'
+
+  - value: 0x0585
+    name: 'Hearing Lab Technology'
+
+  - value: 0x0584
+    name: 'Gira Giersiepen GmbH & Co. KG'
+
+  - value: 0x0583
+    name: 'Code Blue Communications'
+
+  - value: 0x0582
+    name: 'Breakwall Analytics, LLC'
+
+  - value: 0x0581
+    name: 'LYS TECHNOLOGIES LTD'
+
+  - value: 0x0580
+    name: 'ARANZ Medical Limited'
+
+  - value: 0x057F
+    name: 'Scuf Gaming International, LLC'
+
+  - value: 0x057E
+    name: 'Beco, Inc'
+
+  - value: 0x057D
+    name: 'Instinct Performance'
+
+  - value: 0x057C
+    name: 'Toor Technologies LLC'
+
+  - value: 0x057B
+    name: 'Duracell U.S. Operations Inc.'
+
+  - value: 0x057A
+    name: 'OMNI Remotes'
+
+  - value: 0x0579
+    name: 'Ensemble Tech Private Limited'
+
+  - value: 0x0578
+    name: 'Wellington Drive Technologies Ltd'
+
+  - value: 0x0577
+    name: 'True Wearables, Inc.'
+
+  - value: 0x0576
+    name: 'Globalstar, Inc.'
+
+  - value: 0x0575
+    name: 'Integral Memroy Plc'
+
+  - value: 0x0574
+    name: 'AFFORDABLE ELECTRONICS INC'
+
+  - value: 0x0573
+    name: 'Lighting Science Group Corp.'
+
+  - value: 0x0572
+    name: 'AntTail.com'
+
+  - value: 0x0571
+    name: 'PSIKICK, INC.'
+
+  - value: 0x0570
+    name: 'Consumer Sleep Solutions LLC'
+
+  - value: 0x056F
+    name: 'BikeFinder AS'
+
+  - value: 0x056E
+    name: 'VIZPIN INC.'
+
+  - value: 0x056D
+    name: 'Redmond Industrial Group LLC'
+
+  - value: 0x056C
+    name: 'Long Range Systems, LLC'
+
+  - value: 0x056B
+    name: 'Rion Co., Ltd.'
+
+  - value: 0x056A
+    name: 'Flipnavi Co.,Ltd.'
+
+  - value: 0x0569
+    name: 'Audionics System, INC.'
+
+  - value: 0x0568
+    name: 'Bodyport Inc.'
+
+  - value: 0x0567
+    name: 'Xiamen Everesports Goods Co., Ltd'
+
+  - value: 0x0566
+    name: 'CORE TRANSPORT TECHNOLOGIES NZ LIMITED'
+
+  - value: 0x0565
+    name: 'Beijing Smartspace Technologies Inc.'
+
+  - value: 0x0564
+    name: 'Beghelli Spa'
+
+  - value: 0x0563
+    name: 'Steinel Vertrieb GmbH'
+
+  - value: 0x0562
+    name: 'Thalmic Labs Inc.'
+
+  - value: 0x0561
+    name: 'Finder S.p.A.'
+
+  - value: 0x0560
+    name: 'Sarita CareTech APS'
+
+  - value: 0x055F
+    name: 'PROTECH S.A.S. DI GIRARDI ANDREA & C.'
+
+  - value: 0x055E
+    name: 'Hekatron Vertriebs GmbH'
+
+  - value: 0x055D
+    name: 'Valve Corporation'
+
+  - value: 0x055C
+    name: 'Lely'
+
+  - value: 0x055B
+    name: 'FRANKLIN TECHNOLOGY INC'
+
+  - value: 0x055A
+    name: 'CANDY HOUSE, Inc.'
+
+  - value: 0x0559
+    name: 'Newcon Optik'
+
+  - value: 0x0558
+    name: 'benegear, inc.'
+
+  - value: 0x0557
+    name: 'Arwin Technology Limited'
+
+  - value: 0x0556
+    name: 'Otodynamics Ltd'
+
+  - value: 0x0555
+    name: 'KROHNE Messtechnik GmbH'
+
+  - value: 0x0554
+    name: 'National Instruments'
+
+  - value: 0x0553
+    name: 'Nintendo Co., Ltd.'
+
+  - value: 0x0552
+    name: 'Avempace SARL'
+
+  - value: 0x0551
+    name: 'Sylero'
+
+  - value: 0x0550
+    name: 'Versa Networks, Inc.'
+
+  - value: 0x054F
+    name: 'Sinnoz'
+
+  - value: 0x054E
+    name: 'FORTRONIK storitve d.o.o.'
+
+  - value: 0x054D
+    name: 'Sensome'
+
+  - value: 0x054C
+    name: 'Carefree Scott Fetzer Co Inc'
+
+  - value: 0x054B
+    name: 'Advanced Electronic Designs, Inc.'
+
+  - value: 0x054A
+    name: 'Linough Inc.'
+
+  - value: 0x0549
+    name: 'Smart Technologies and Investment Limited'
+
+  - value: 0x0548
+    name: 'Knick Elektronische Messgeraete GmbH & Co. KG'
+
+  - value: 0x0547
+    name: 'LOGICDATA Electronic & Software Entwicklungs GmbH'
+
+  - value: 0x0546
+    name: 'Apexar Technologies S.A.'
+
+  - value: 0x0545
+    name: 'Candy Hoover Group s.r.l'
+
+  - value: 0x0544
+    name: 'OrthoSensor, Inc.'
+
+  - value: 0x0543
+    name: 'MIWA LOCK CO.,Ltd'
+
+  - value: 0x0542
+    name: 'Mist Systems, Inc.'
+
+  - value: 0x0541
+    name: 'Sharknet srl'
+
+  - value: 0x0540
+    name: 'SilverPlus, Inc'
+
+  - value: 0x053F
+    name: 'Silergy Corp'
+
+  - value: 0x053E
+    name: 'CLIM8 LIMITED'
+
+  - value: 0x053D
+    name: 'TESA SA'
+
+  - value: 0x053C
+    name: 'Screenovate Technologies Ltd'
+
+  - value: 0x053B
+    name: 'prodigy'
+
+  - value: 0x053A
+    name: 'Savitech Corp.,'
+
+  - value: 0x0539
+    name: 'OPPLE Lighting Co., Ltd'
+
+  - value: 0x0538
+    name: 'Medela AG'
+
+  - value: 0x0537
+    name: 'MetaLogics Corporation'
+
+  - value: 0x0536
+    name: 'ZTR Control Systems LLC'
+
+  - value: 0x0535
+    name: 'Smart Component Technologies Limited'
+
+  - value: 0x0534
+    name: 'Frontiergadget, Inc.'
+
+  - value: 0x0533
+    name: 'Nura Operations Pty Ltd'
+
+  - value: 0x0532
+    name: 'CRESCO Wireless, Inc.'
+
+  - value: 0x0531
+    name: 'D&M Holdings Inc.'
+
+  - value: 0x0530
+    name: 'Adolene, Inc.'
+
+  - value: 0x052F
+    name: 'Center ID Corp.'
+
+  - value: 0x052E
+    name: 'LEDVANCE GmbH'
+
+  - value: 0x052D
+    name: 'EXFO, Inc.'
+
+  - value: 0x052C
+    name: 'Geosatis SA'
+
+  - value: 0x052B
+    name: 'Novartis AG'
+
+  - value: 0x052A
+    name: 'Keynes Controls Ltd'
+
+  - value: 0x0529
+    name: 'Lumen UAB'
+
+  - value: 0x0528
+    name: 'Lunera Lighting Inc.'
+
+  - value: 0x0527
+    name: 'Albrecht JUNG'
+
+  - value: 0x0526
+    name: 'Honeywell International Inc.'
+
+  - value: 0x0525
+    name: 'HONGKONG NANO IC TECHNOLOGIES  CO., LIMITED'
+
+  - value: 0x0524
+    name: 'Hangzhou iMagic Technology Co., Ltd'
+
+  - value: 0x0523
+    name: 'MTG Co., Ltd.'
+
+  - value: 0x0522
+    name: 'NS Tech, Inc.'
+
+  - value: 0x0521
+    name: 'IAI Corporation'
+
+  - value: 0x0520
+    name: 'Target Corporation'
+
+  - value: 0x051F
+    name: 'Setec Pty Ltd'
+
+  - value: 0x051E
+    name: 'Detect Blue Limited'
+
+  - value: 0x051D
+    name: 'OFF Line Co., Ltd.'
+
+  - value: 0x051C
+    name: 'EDPS'
+
+  - value: 0x051B
+    name: 'Angee Technologies Ltd.'
+
+  - value: 0x051A
+    name: 'Leica Camera AG'
+
+  - value: 0x0519
+    name: 'Tyto Life LLC'
+
+  - value: 0x0518
+    name: 'MAMORIO.inc'
+
+  - value: 0x0517
+    name: 'Amtronic Sverige AB'
+
+  - value: 0x0516
+    name: 'Footmarks'
+
+  - value: 0x0515
+    name: 'RB Controls Co., Ltd.'
+
+  - value: 0x0514
+    name: 'FIBRO GmbH'
+
+  - value: 0x0513
+    name: '9974091 Canada Inc.'
+
+  - value: 0x0512
+    name: 'Soprod SA'
+
+  - value: 0x0511
+    name: 'Brookfield Equinox LLC'
+
+  - value: 0x0510
+    name: 'UNI-ELECTRONICS, INC.'
+
+  - value: 0x050F
+    name: 'Foundation Engineering LLC'
+
+  - value: 0x050E
+    name: 'Yichip Microelectronics (Hangzhou) Co.,Ltd.'
+
+  - value: 0x050D
+    name: 'TRSystems GmbH'
+
+  - value: 0x050C
+    name: 'OSRAM GmbH'
+
+  - value: 0x050B
+    name: 'Vibrissa Inc.'
+
+  - value: 0x050A
+    name: 'Shake-on B.V.'
+
+  - value: 0x0509
+    name: 'Garage Smart, Inc.'
+
+  - value: 0x0508
+    name: 'Axes System sp. z o. o.'
+
+  - value: 0x0507
+    name: 'Yellowcog'
+
+  - value: 0x0506
+    name: 'Hager'
+
+  - value: 0x0505
+    name: 'InPlay, Inc.'
+
+  - value: 0x0504
+    name: 'PHYPLUS Inc'
+
+  - value: 0x0503
+    name: 'Locoroll, Inc'
+
+  - value: 0x0502
+    name: 'Specifi-Kali LLC'
+
+  - value: 0x0501
+    name: 'Polaris IND'
+
+  - value: 0x0500
+    name: 'Wiliot LTD.'
+
+  - value: 0x04FF
+    name: 'Microsemi Corporation'
+
+  - value: 0x04FE
+    name: 'Woosim Systems Inc.'
+
+  - value: 0x04FD
+    name: 'Tapkey GmbH'
+
+  - value: 0x04FC
+    name: 'SwingLync L. L. C.'
+
+  - value: 0x04FB
+    name: 'Benchmark Drives GmbH & Co. KG'
+
+  - value: 0x04FA
+    name: 'Androtec GmbH'
+
+  - value: 0x04F9
+    name: 'Interactio'
+
+  - value: 0x04F8
+    name: 'Convergence Systems Limited'
+
+  - value: 0x04F7
+    name: 'Shenzhen Goodix Technology Co., Ltd'
+
+  - value: 0x04F6
+    name: 'McLear Limited'
+
+  - value: 0x04F5
+    name: 'Pirelli Tyre S.P.A.'
+
+  - value: 0x04F4
+    name: 'ZanCompute Inc.'
+
+  - value: 0x04F3
+    name: 'Cerevast Medical'
+
+  - value: 0x04F2
+    name: 'InDreamer Techsol Private Limited'
+
+  - value: 0x04F1
+    name: 'Theben AG'
+
+  - value: 0x04F0
+    name: 'Kosi Limited'
+
+  - value: 0x04EF
+    name: 'DaisyWorks, Inc'
+
+  - value: 0x04EE
+    name: 'Auxivia'
+
+  - value: 0x04ED
+    name: 'R9 Technology, Inc.'
+
+  - value: 0x04EC
+    name: 'Motorola Solutions'
+
+  - value: 0x04EB
+    name: 'Bird Home Automation GmbH'
+
+  - value: 0x04EA
+    name: 'Pacific Bioscience Laboratories, Inc'
+
+  - value: 0x04E9
+    name: 'Busch Jaeger Elektro GmbH'
+
+  - value: 0x04E8
+    name: 'STABILO International'
+
+  - value: 0x04E7
+    name: 'REHABTRONICS INC.'
+
+  - value: 0x04E6
+    name: 'Smart Solution Technology, Inc.'
+
+  - value: 0x04E5
+    name: 'Avack Oy'
+
+  - value: 0x04E4
+    name: 'Woodenshark'
+
+  - value: 0x04E3
+    name: 'Under Armour'
+
+  - value: 0x04E2
+    name: 'EllieGrid'
+
+  - value: 0x04E1
+    name: 'REACTEC LIMITED'
+
+  - value: 0x04E0
+    name: 'Guardtec, Inc.'
+
+  - value: 0x04DF
+    name: 'Emerson Electric Co.'
+
+  - value: 0x04DE
+    name: 'Lutron Electronics Co., Inc.'
+
+  - value: 0x04DD
+    name: '4MOD Technology'
+
+  - value: 0x04DC
+    name: 'IOTTIVE (OPC) PRIVATE LIMITED'
+
+  - value: 0x04DB
+    name: 'Engineered Audio, LLC.'
+
+  - value: 0x04DA
+    name: 'Franceschi Marina snc'
+
+  - value: 0x04D9
+    name: 'RM Acquisition LLC'
+
+  - value: 0x04D8
+    name: 'FUJIFILM Corporation'
+
+  - value: 0x04D7
+    name: 'Blincam, Inc.'
+
+  - value: 0x04D6
+    name: 'LUGLOC LLC'
+
+  - value: 0x04D5
+    name: 'Gooee Limited'
+
+  - value: 0x04D4
+    name: '5th Element Ltd'
+
+  - value: 0x04D3
+    name: 'Queercon, Inc'
+
+  - value: 0x04D2
+    name: 'Anloq Technologies Inc.'
+
+  - value: 0x04D1
+    name: 'KTS GmbH'
+
+  - value: 0x04D0
+    name: 'Olympus Corporation'
+
+  - value: 0x04CF
+    name: 'DOM Sicherheitstechnik GmbH & Co. KG'
+
+  - value: 0x04CE
+    name: 'GOOOLED S.R.L.'
+
+  - value: 0x04CD
+    name: 'Safetech Products LLC'
+
+  - value: 0x04CC
+    name: 'Enflux Inc.'
+
+  - value: 0x04CB
+    name: 'Novo Nordisk A/S'
+
+  - value: 0x04CA
+    name: 'Steiner-Optik GmbH'
+
+  - value: 0x04C9
+    name: 'Thornwave Labs Inc'
+
+  - value: 0x04C8
+    name: 'Shanghai Flyco Electrical Appliance Co., Ltd.'
+
+  - value: 0x04C7
+    name: 'Svantek Sp. z o.o.'
+
+  - value: 0x04C6
+    name: 'Insta GmbH'
+
+  - value: 0x04C5
+    name: 'Seibert Williams Glass, LLC'
+
+  - value: 0x04C4
+    name: 'TeAM Hutchins AB'
+
+  - value: 0x04C3
+    name: 'Mantracourt Electronics Limited'
+
+  - value: 0x04C2
+    name: 'Dmet Products Corp.'
+
+  - value: 0x04C1
+    name: 'Sospitas, s.r.o.'
+
+  - value: 0x04C0
+    name: 'Statsports International'
+
+  - value: 0x04BF
+    name: 'VIT Initiative, LLC'
+
+  - value: 0x04BE
+    name: 'Averos FZCO'
+
+  - value: 0x04BD
+    name: 'AlbynMedical'
+
+  - value: 0x04BC
+    name: 'Draegerwerk AG & Co. KGaA'
+
+  - value: 0x04BB
+    name: 'Neatebox Ltd'
+
+  - value: 0x04BA
+    name: 'Crestron Electronics, Inc.'
+
+  - value: 0x04B9
+    name: 'CSR Building Products Limited'
+
+  - value: 0x04B8
+    name: 'Soraa Inc.'
+
+  - value: 0x04B7
+    name: 'Analog Devices, Inc.'
+
+  - value: 0x04B6
+    name: 'Diagnoptics Technologies'
+
+  - value: 0x04B5
+    name: 'Swiftronix AB'
+
+  - value: 0x04B4
+    name: 'Inuheat Group AB'
+
+  - value: 0x04B3
+    name: 'mobike (Hong Kong) Limited'
+
+  - value: 0x04B2
+    name: 'The Shadow on the Moon'
+
+  - value: 0x04B1
+    name: 'Kartographers Technologies Pvt. Ltd.'
+
+  - value: 0x04B0
+    name: 'Weba Sport und Med. Artikel GmbH'
+
+  - value: 0x04AF
+    name: 'BIOROWER Handelsagentur GmbH'
+
+  - value: 0x04AE
+    name: 'ERM Electronic Systems LTD'
+
+  - value: 0x04AD
+    name: 'Shure Inc'
+
+  - value: 0x04AC
+    name: 'Undagrid B.V.'
+
+  - value: 0x04AB
+    name: 'Harbortronics, Inc.'
+
+  - value: 0x04AA
+    name: 'LINKIO SAS'
+
+  - value: 0x04A9
+    name: 'DISCOVERY SOUND TECHNOLOGY, LLC'
+
+  - value: 0x04A8
+    name: 'BioTex, Inc.'
+
+  - value: 0x04A7
+    name: 'Dallas Logic Corporation'
+
+  - value: 0x04A6
+    name: 'Vinetech Co., Ltd'
+
+  - value: 0x04A5
+    name: 'Guangzhou FiiO Electronics Technology Co.,Ltd'
+
+  - value: 0x04A4
+    name: 'Herbert Waldmann GmbH & Co. KG'
+
+  - value: 0x04A3
+    name: 'GT-tronics HK Ltd'
+
+  - value: 0x04A2
+    name: 'ovrEngineered, LLC'
+
+  - value: 0x04A1
+    name: 'PNI Sensor Corporation'
+
+  - value: 0x04A0
+    name: 'Vypin, LLC'
+
+  - value: 0x049F
+    name: 'Popper Pay AB'
+
+  - value: 0x049E
+    name: 'AND!XOR LLC'
+
+  - value: 0x049D
+    name: 'Uhlmann & Zacher GmbH'
+
+  - value: 0x049C
+    name: 'DyOcean'
+
+  - value: 0x049B
+    name: 'nVisti, LLC'
+
+  - value: 0x049A
+    name: 'Situne AS'
+
+  - value: 0x0499
+    name: 'Ruuvi Innovations Ltd.'
+
+  - value: 0x0498
+    name: 'METER Group, Inc. USA'
+
+  - value: 0x0497
+    name: 'Cochlear Limited'
+
+  - value: 0x0496
+    name: 'Polymorphic Labs LLC'
+
+  - value: 0x0495
+    name: 'LMT Mercer Group, Inc'
+
+  - value: 0x0494
+    name: 'SENNHEISER electronic GmbH & Co. KG'
+
+  - value: 0x0493
+    name: 'Lynxemi Pte Ltd'
+
+  - value: 0x0492
+    name: 'ADC Technology, Inc.'
+
+  - value: 0x0491
+    name: 'SOREX - Wireless Solutions GmbH'
+
+  - value: 0x0490
+    name: 'Matting AB'
+
+  - value: 0x048F
+    name: 'BlueKitchen GmbH'
+
+  - value: 0x048E
+    name: 'Companion Medical, Inc.'
+
+  - value: 0x048D
+    name: 'S-Labs Sp. z o.o.'
+
+  - value: 0x048C
+    name: 'Vectronix AG'
+
+  - value: 0x048B
+    name: 'CP Electronics Limited'
+
+  - value: 0x048A
+    name: 'Taelek Oy'
+
+  - value: 0x0489
+    name: 'Igarashi Engineering'
+
+  - value: 0x0488
+    name: 'Automotive Data Solutions Inc'
+
+  - value: 0x0487
+    name: 'Centrica Connected Home'
+
+  - value: 0x0486
+    name: 'DEV TECNOLOGIA INDUSTRIA, COMERCIO E MANUTENCAO DE EQUIPAMENTOS LTDA. - ME'
+
+  - value: 0x0485
+    name: 'SKIDATA AG'
+
+  - value: 0x0484
+    name: 'Revol Technologies Inc'
+
+  - value: 0x0483
+    name: 'Multi Care Systems B.V.'
+
+  - value: 0x0482
+    name: 'POS Tuning Udo Vosshenrich GmbH & Co. KG'
+
+  - value: 0x0481
+    name: 'Quintrax Limited'
+
+  - value: 0x0480
+    name: 'Dynometrics Inc.'
+
+  - value: 0x047F
+    name: 'Pro-Mark, Inc.'
+
+  - value: 0x047E
+    name: 'OurHub Dev IvS'
+
+  - value: 0x047D
+    name: 'Occly LLC'
+
+  - value: 0x047C
+    name: 'POWERMAT LTD'
+
+  - value: 0x047B
+    name: 'MIYOSHI ELECTRONICS CORPORATION'
+
+  - value: 0x047A
+    name: 'Sinosun Technology Co., Ltd.'
+
+  - value: 0x0479
+    name: 'mywerk system GmbH'
+
+  - value: 0x0478
+    name: 'FarSite Communications Limited'
+
+  - value: 0x0477
+    name: 'Blue Spark Technologies'
+
+  - value: 0x0476
+    name: 'Oxstren Wearable Technologies Private Limited'
+
+  - value: 0x0475
+    name: 'Icom inc.'
+
+  - value: 0x0474
+    name: 'iApartment co., ltd.'
+
+  - value: 0x0473
+    name: 'Steelcase, Inc.'
+
+  - value: 0x0472
+    name: 'Control-J Pty Ltd'
+
+  - value: 0x0471
+    name: 'TiVo Corp'
+
+  - value: 0x0470
+    name: 'iDesign s.r.l.'
+
+  - value: 0x046F
+    name: 'Develco Products A/S'
+
+  - value: 0x046E
+    name: 'Pambor Ltd.'
+
+  - value: 0x046D
+    name: 'BEGA Gantenbrink-Leuchten KG'
+
+  - value: 0x046C
+    name: 'Qingdao Realtime Technology Co., Ltd.'
+
+  - value: 0x046B
+    name: 'PMD Solutions'
+
+  - value: 0x046A
+    name: 'INSIGMA INC.'
+
+  - value: 0x0469
+    name: 'Palago AB'
+
+  - value: 0x0468
+    name: 'Kynesim Ltd'
+
+  - value: 0x0467
+    name: 'Codenex Oy'
+
+  - value: 0x0466
+    name: 'CycleLabs Solutions inc.'
+
+  - value: 0x0465
+    name: 'International Forte Group LLC'
+
+  - value: 0x0464
+    name: 'Bellman & Symfon Group AB'
+
+  - value: 0x0463
+    name: 'Fathom Systems Inc.'
+
+  - value: 0x0462
+    name: 'Bonsai Systems GmbH'
+
+  - value: 0x0461
+    name: 'vhf elektronik GmbH'
+
+  - value: 0x0460
+    name: 'Kolibree'
+
+  - value: 0x045F
+    name: 'Real Time Automation, Inc.'
+
+  - value: 0x045E
+    name: 'Nuviz, Inc.'
+
+  - value: 0x045D
+    name: 'Boston Scientific Corporation'
+
+  - value: 0x045C
+    name: 'Delta T Corporation'
+
+  - value: 0x045B
+    name: 'SPACEEK LTD'
+
+  - value: 0x045A
+    name: '2048450 Ontario Inc'
+
+  - value: 0x0459
+    name: 'Lumenetix, Inc'
+
+  - value: 0x0458
+    name: 'Mini Solution Co., Ltd.'
+
+  - value: 0x0457
+    name: 'RF INNOVATION'
+
+  - value: 0x0456
+    name: 'Nemik Consulting Inc'
+
+  - value: 0x0455
+    name: 'Atomation'
+
+  - value: 0x0454
+    name: 'Sphinx Electronics GmbH & Co KG'
+
+  - value: 0x0453
+    name: 'Qorvo Utrecht B.V.'
+
+  - value: 0x0452
+    name: 'Svep Design Center AB'
+
+  - value: 0x0451
+    name: 'Tunstall Nordic AB'
+
+  - value: 0x0450
+    name: 'Teenage Engineering AB'
+
+  - value: 0x044F
+    name: 'TTS Tooltechnic Systems AG & Co. KG'
+
+  - value: 0x044E
+    name: 'Xtrava Inc.'
+
+  - value: 0x044D
+    name: 'VEGA Grieshaber KG'
+
+  - value: 0x044C
+    name: 'LifeStyle Lock, LLC'
+
+  - value: 0x044B
+    name: 'Nain Inc.'
+
+  - value: 0x044A
+    name: 'SHIMANO INC.'
+
+  - value: 0x0449
+    name: '1UP USA.com llc'
+
+  - value: 0x0448
+    name: 'Grand Centrix GmbH'
+
+  - value: 0x0447
+    name: 'Fabtronics Australia Pty Ltd'
+
+  - value: 0x0446
+    name: 'NETGEAR, Inc.'
+
+  - value: 0x0445
+    name: 'Kobian Canada Inc.'
+
+  - value: 0x0444
+    name: 'Metanate Limited'
+
+  - value: 0x0443
+    name: 'Tucker International LLC'
+
+  - value: 0x0442
+    name: 'SECOM CO., LTD.'
+
+  - value: 0x0441
+    name: 'iProtoXi Oy'
+
+  - value: 0x0440
+    name: 'Valencell, Inc.'
+
+  - value: 0x043F
+    name: 'Tentacle Sync GmbH'
+
+  - value: 0x043E
+    name: 'Thermomedics, Inc.'
+
+  - value: 0x043D
+    name: 'Coiler Corporation'
+
+  - value: 0x043C
+    name: 'DeLaval'
+
+  - value: 0x043B
+    name: 'Appside co., ltd.'
+
+  - value: 0x043A
+    name: 'Nuheara Limited'
+
+  - value: 0x0439
+    name: 'Radiance Technologies'
+
+  - value: 0x0438
+    name: 'Helvar Ltd'
+
+  - value: 0x0437
+    name: 'eBest IOT Inc.'
+
+  - value: 0x0436
+    name: 'Drayson Technologies (Europe) Limited'
+
+  - value: 0x0435
+    name: 'Blocks Wearables Ltd.'
+
+  - value: 0x0434
+    name: 'Hatch Baby, Inc.'
+
+  - value: 0x0433
+    name: 'Pillsy Inc.'
+
+  - value: 0x0432
+    name: 'Silk Labs, Inc.'
+
+  - value: 0x0431
+    name: 'Alticor Inc.'
+
+  - value: 0x0430
+    name: 'SnapStyk Inc.'
+
+  - value: 0x042F
+    name: 'Danfoss A/S'
+
+  - value: 0x042E
+    name: 'MemCachier Inc.'
+
+  - value: 0x042D
+    name: 'Meshtech AS'
+
+  - value: 0x042C
+    name: 'Ticto N.V.'
+
+  - value: 0x042B
+    name: 'iMicroMed Incorporated'
+
+  - value: 0x042A
+    name: 'BD Medical'
+
+  - value: 0x0429
+    name: 'Prolon Inc.'
+
+  - value: 0x0428
+    name: 'SmallLoop, LLC'
+
+  - value: 0x0427
+    name: 'Focus fleet and fuel management inc'
+
+  - value: 0x0426
+    name: 'Husqvarna AB'
+
+  - value: 0x0425
+    name: 'Unify Software and Solutions GmbH & Co. KG'
+
+  - value: 0x0424
+    name: 'Trainesense Ltd.'
+
+  - value: 0x0423
+    name: 'Chargifi Limited'
+
+  - value: 0x0422
+    name: 'DELSEY SA'
+
+  - value: 0x0421
+    name: 'Backbone Labs, Inc.'
+
+  - value: 0x0420
+    name: 'TecBakery GmbH'
+
+  - value: 0x041F
+    name: 'Kopin Corporation'
+
+  - value: 0x041E
+    name: 'Dell Computer Corporation'
+
+  - value: 0x041D
+    name: 'Benning Elektrotechnik und Elektronik GmbH & Co. KG'
+
+  - value: 0x041C
+    name: 'WaterGuru, Inc.'
+
+  - value: 0x041B
+    name: 'OrthoAccel Technologies'
+
+  - value: 0x041A
+    name: 'Friday Labs Limited'
+
+  - value: 0x0419
+    name: 'Novalogy LTD'
+
+  - value: 0x0417
+    name: 'Fatigue Science'
+
+  - value: 0x0416
+    name: 'SODA GmbH'
+
+  - value: 0x0415
+    name: 'Uber Technologies Inc'
+
+  - value: 0x0414
+    name: 'Lightning Protection International Pty Ltd'
+
+  - value: 0x0413
+    name: 'Wireless Cables Inc'
+
+  - value: 0x0412
+    name: 'SEFAM'
+
+  - value: 0x0411
+    name: 'Luidia Inc'
+
+  - value: 0x0410
+    name: 'Fender Musical Instruments'
+
+  - value: 0x040F
+    name: 'CO-AX Technology, Inc.'
+
+  - value: 0x040E
+    name: 'SKF (U.K.) Limited'
+
+  - value: 0x040D
+    name: 'NorthStar Battery Company, LLC'
+
+  - value: 0x040C
+    name: 'Senix Corporation'
+
+  - value: 0x040B
+    name: 'Jana Care Inc.'
+
+  - value: 0x040A
+    name: 'ZF OPENMATICS s.r.o.'
+
+  - value: 0x0409
+    name: 'RYSE INC.'
+
+  - value: 0x0408
+    name: 'ToGetHome Inc.'
+
+  - value: 0x0407
+    name: 'Swiss Audio SA'
+
+  - value: 0x0406
+    name: 'Airtago'
+
+  - value: 0x0405
+    name: 'Vertex International, Inc.'
+
+  - value: 0x0404
+    name: 'Authomate Inc'
+
+  - value: 0x0403
+    name: 'Gantner Electronic GmbH'
+
+  - value: 0x0402
+    name: 'Sears Holdings Corporation'
+
+  - value: 0x0401
+    name: 'Relations Inc.'
+
+  - value: 0x0400
+    name: 'i-developer IT Beratung UG'
+
+  - value: 0x03FF
+    name: 'Withings'
+
+  - value: 0x03FE
+    name: 'Littelfuse'
+
+  - value: 0x03FD
+    name: 'Trimble Inc.'
+
+  - value: 0x03FC
+    name: 'Kimberly-Clark'
+
+  - value: 0x03FB
+    name: 'Nox Medical'
+
+  - value: 0x03FA
+    name: 'Vyassoft Technologies Inc'
+
+  - value: 0x03F9
+    name: 'Becon Technologies Co.,Ltd.'
+
+  - value: 0x03F8
+    name: 'Rockford Corp.'
+
+  - value: 0x03F7
+    name: 'Owl Labs Inc.'
+
+  - value: 0x03F6
+    name: 'Iton Technology Corp.'
+
+  - value: 0x03F5
+    name: 'WHERE, Inc.'
+
+  - value: 0x03F4
+    name: 'PAL Technologies Ltd'
+
+  - value: 0x03F3
+    name: 'Flowscape AB'
+
+  - value: 0x03F2
+    name: 'WindowMaster A/S'
+
+  - value: 0x03F1
+    name: 'Hestan Smart Cooking Inc.'
+
+  - value: 0x03F0
+    name: 'CLINK'
+
+  - value: 0x03EF
+    name: 'foolography GmbH'
+
+  - value: 0x03EE
+    name: 'CUBE TECHNOLOGIES'
+
+  - value: 0x03ED
+    name: 'BASIC MICRO.COM,INC.'
+
+  - value: 0x03EC
+    name: 'Jigowatts Inc.'
+
+  - value: 0x03EB
+    name: 'Ozo Edu, Inc.'
+
+  - value: 0x03EA
+    name: 'Hello Inc.'
+
+  - value: 0x03E9
+    name: 'SHENZHEN LEMONJOY TECHNOLOGY CO., LTD.'
+
+  - value: 0x03E8
+    name: 'Reiner Kartengeraete GmbH & Co. KG.'
+
+  - value: 0x03E7
+    name: 'TRUE Fitness Technology'
+
+  - value: 0x03E6
+    name: 'IoT Instruments Oy'
+
+  - value: 0x03E5
+    name: 'ffly4u'
+
+  - value: 0x03E4
+    name: 'Chip-ing AG'
+
+  - value: 0x03E3
+    name: 'Qualcomm Life Inc'
+
+  - value: 0x03E2
+    name: 'Sensoan Oy'
+
+  - value: 0x03E1
+    name: 'SPD Development Company Ltd'
+
+  - value: 0x03E0
+    name: 'Actions Technology Co.,Ltd'
+
+  - value: 0x03DF
+    name: 'Grob Technologies, LLC'
+
+  - value: 0x03DE
+    name: 'Nathan Rhoades LLC'
+
+  - value: 0x03DD
+    name: 'Andreas Stihl AG & Co. KG'
+
+  - value: 0x03DC
+    name: 'Nima Labs'
+
+  - value: 0x03DB
+    name: 'Instabeat, Inc'
+
+  - value: 0x03DA
+    name: 'EnOcean GmbH'
+
+  - value: 0x03D9
+    name: '3IWare Co., Ltd.'
+
+  - value: 0x03D8
+    name: 'Zen-Me Labs Ltd'
+
+  - value: 0x03D7
+    name: 'FINSECUR'
+
+  - value: 0x03D6
+    name: 'Yota Devices LTD'
+
+  - value: 0x03D5
+    name: 'Wyzelink Systems Inc.'
+
+  - value: 0x03D4
+    name: 'PEG PEREGO SPA'
+
+  - value: 0x03D3
+    name: 'Sigma Connectivity AB'
+
+  - value: 0x03D2
+    name: 'IOT Pot India Private Limited'
+
+  - value: 0x03D1
+    name: 'Density Inc.'
+
+  - value: 0x03D0
+    name: 'Watteam Ltd'
+
+  - value: 0x03CF
+    name: 'MIRA, Inc.'
+
+  - value: 0x03CE
+    name: 'CONTRINEX S.A.'
+
+  - value: 0x03CD
+    name: 'Wynd Technologies, Inc.'
+
+  - value: 0x03CC
+    name: 'Vonkil Technologies Ltd'
+
+  - value: 0x03CB
+    name: 'SYSDEV Srl'
+
+  - value: 0x03CA
+    name: 'In2things Automation Pvt. Ltd.'
+
+  - value: 0x03C9
+    name: 'Gallagher Group'
+
+  - value: 0x03C8
+    name: 'Avvel International'
+
+  - value: 0x03C7
+    name: 'Structural Health Systems, Inc.'
+
+  - value: 0x03C6
+    name: 'Intricon'
+
+  - value: 0x03C5
+    name: 'St. Jude Medical, Inc.'
+
+  - value: 0x03C4
+    name: 'Pico Technology Inc.'
+
+  - value: 0x03C3
+    name: 'Casambi Technologies Oy'
+
+  - value: 0x03C2
+    name: 'Snapchat Inc'
+
+  - value: 0x03C1
+    name: 'Ember Technologies, Inc.'
+
+  - value: 0x03C0
+    name: 'Arch Systems Inc.'
+
+  - value: 0x03BF
+    name: 'iLumi Solutions Inc.'
+
+  - value: 0x03BE
+    name: 'Applied Science, Inc.'
+
+  - value: 0x03BD
+    name: 'amadas'
+
+  - value: 0x03BC
+    name: 'ASB Bank Ltd'
+
+  - value: 0x03BB
+    name: 'Abbott'
+
+  - value: 0x03BA
+    name: 'Maxscend Microelectronics Company Limited'
+
+  - value: 0x03B9
+    name: 'FREDERIQUE CONSTANT SA'
+
+  - value: 0x03B8
+    name: 'A-Safe Limited'
+
+  - value: 0x03B7
+    name: 'Airbly Inc.'
+
+  - value: 0x03B6
+    name: 'Mattel'
+
+  - value: 0x03B5
+    name: 'petPOMM, Inc'
+
+  - value: 0x03B4
+    name: 'Alpha Nodus, inc.'
+
+  - value: 0x03B3
+    name: 'Midwest Instruments & Controls'
+
+  - value: 0x03B2
+    name: 'Propagation Systems Limited'
+
+  - value: 0x03B1
+    name: 'Otodata Wireless Network Inc.'
+
+  - value: 0x03B0
+    name: 'VIBRADORM GmbH'
+
+  - value: 0x03AF
+    name: 'Comm-N-Sense Corp DBA Verigo'
+
+  - value: 0x03AE
+    name: 'Allswell Inc.'
+
+  - value: 0x03AD
+    name: 'XiQ'
+
+  - value: 0x03AC
+    name: 'Smablo LTD'
+
+  - value: 0x03AB
+    name: 'Meizu Technology Co., Ltd.'
+
+  - value: 0x03AA
+    name: 'Exon Sp. z o.o.'
+
+  - value: 0x03A9
+    name: 'THINKERLY SRL'
+
+  - value: 0x03A8
+    name: 'Esrille Inc.'
+
+  - value: 0x03A7
+    name: 'AeroScout'
+
+  - value: 0x03A6
+    name: 'Medela, Inc'
+
+  - value: 0x03A5
+    name: 'ACE CAD Enterprise Co., Ltd. (ACECAD)'
+
+  - value: 0x03A4
+    name: 'Token Zero Ltd'
+
+  - value: 0x03A3
+    name: 'SmartMovt Technology Co., Ltd'
+
+  - value: 0x03A2
+    name: 'Candura Instruments'
+
+  - value: 0x03A1
+    name: 'Alpine Labs LLC'
+
+  - value: 0x03A0
+    name: 'IVT Wireless Limited'
+
+  - value: 0x039F
+    name: 'Molex Corporation'
+
+  - value: 0x039E
+    name: 'SchoolBoard Limited'
+
+  - value: 0x039D
+    name: 'CareView Communications, Inc.'
+
+  - value: 0x039C
+    name: 'ALE International'
+
+  - value: 0x039B
+    name: 'South Silicon Valley Microelectronics'
+
+  - value: 0x039A
+    name: 'NeST'
+
+  - value: 0x0399
+    name: 'Nikon Corporation'
+
+  - value: 0x0398
+    name: 'Thetatronics Ltd'
+
+  - value: 0x0397
+    name: 'LEGO System A/S'
+
+  - value: 0x0396
+    name: 'BLOKS GmbH'
+
+  - value: 0x0395
+    name: 'SDATAWAY'
+
+  - value: 0x0394
+    name: 'Netclearance Systems, Inc.'
+
+  - value: 0x0393
+    name: 'LAVAZZA S.p.A.'
+
+  - value: 0x0392
+    name: 'T&D'
+
+  - value: 0x0391
+    name: 'Thingsquare AB'
+
+  - value: 0x0390
+    name: 'INFOTECH s.r.o.'
+
+  - value: 0x038F
+    name: 'Xiaomi Inc.'
+
+  - value: 0x038E
+    name: 'Crownstone B.V.'
+
+  - value: 0x038D
+    name: 'Resmed Ltd'
+
+  - value: 0x038C
+    name: 'Appion Inc.'
+
+  - value: 0x038B
+    name: 'Noke'
+
+  - value: 0x038A
+    name: 'Kohler Mira Limited'
+
+  - value: 0x0389
+    name: 'ActiveBlu Corporation'
+
+  - value: 0x0388
+    name: 'Kapsch TrafficCom AB'
+
+  - value: 0x0387
+    name: 'BluStor PMC, Inc.'
+
+  - value: 0x0386
+    name: 'Aterica Inc.'
+
+  - value: 0x0385
+    name: 'Embedded Electronic Solutions Ltd. dba e2Solutions'
+
+  - value: 0x0384
+    name: 'OCOSMOS Co., Ltd.'
+
+  - value: 0x0383
+    name: 'Kronos Incorporated'
+
+  - value: 0x0382
+    name: 'Precision Outcomes Ltd'
+
+  - value: 0x0381
+    name: 'Sharp Corporation'
+
+  - value: 0x0380
+    name: 'LLC "MEGA-F service"'
+
+  - value: 0x037F
+    name: 'Société des Produits Nestlé S.A.'
+
+  - value: 0x037E
+    name: 'lulabytes S.L.'
+
+  - value: 0x037D
+    name: 'MICRODIA Ltd.'
+
+  - value: 0x037C
+    name: 'Cronologics Corporation'
+
+  - value: 0x037B
+    name: 'Apption Labs Inc.'
+
+  - value: 0x037A
+    name: 'Algoria'
+
+  - value: 0x0379
+    name: 'Shenzhen iMCO Electronic Technology Co.,Ltd'
+
+  - value: 0x0378
+    name: 'Propeller Health'
+
+  - value: 0x0377
+    name: 'Plejd AB'
+
+  - value: 0x0376
+    name: 'Electronic Temperature Instruments Ltd'
+
+  - value: 0x0375
+    name: 'Expain AS'
+
+  - value: 0x0374
+    name: 'Holman Industries'
+
+  - value: 0x0373
+    name: 'AppNearMe Ltd'
+
+  - value: 0x0372
+    name: 'Nixie Labs, Inc.'
+
+  - value: 0x0371
+    name: 'ORBCOMM'
+
+  - value: 0x0370
+    name: 'Wazombi Labs OÜ'
+
+  - value: 0x036F
+    name: 'Motiv, Inc.'
+
+  - value: 0x036E
+    name: 'MOTIVE TECHNOLOGIES, INC.'
+
+  - value: 0x036D
+    name: 'AirBolt Pty Ltd'
+
+  - value: 0x036C
+    name: 'Zipcar'
+
+  - value: 0x036B
+    name: 'BRControls Products BV'
+
+  - value: 0x036A
+    name: 'SetPoint Medical'
+
+  - value: 0x0369
+    name: 'littleBits'
+
+  - value: 0x0368
+    name: 'Metormote AB'
+
+  - value: 0x0367
+    name: 'Saphe International'
+
+  - value: 0x0366
+    name: 'BOLTT Sports technologies Private limited'
+
+  - value: 0x0365
+    name: 'BioMech Sensor LLC'
+
+  - value: 0x0364
+    name: 'Favero Electronics Srl'
+
+  - value: 0x0363
+    name: 'FREELAP SA'
+
+  - value: 0x0362
+    name: 'ON Semiconductor'
+
+  - value: 0x0361
+    name: 'Wellinks Inc.'
+
+  - value: 0x0360
+    name: 'Insulet Corporation'
+
+  - value: 0x035F
+    name: 'Acromag'
+
+  - value: 0x035E
+    name: 'Naya Health, Inc.'
+
+  - value: 0x035D
+    name: 'KYS'
+
+  - value: 0x035C
+    name: 'Eaton Corporation'
+
+  - value: 0x035B
+    name: 'Matrix Inc.'
+
+  - value: 0x035A
+    name: 'Phillips-Medisize A/S'
+
+  - value: 0x0359
+    name: 'Novotec Medical GmbH'
+
+  - value: 0x0358
+    name: 'MagniWare Ltd.'
+
+  - value: 0x0357
+    name: 'Polymap Wireless'
+
+  - value: 0x0356
+    name: 'Spectrum Brands, Inc.'
+
+  - value: 0x0355
+    name: 'Sigma Designs, Inc.'
+
+  - value: 0x0354
+    name: 'TOPPAN FORMS CO.,LTD.'
+
+  - value: 0x0353
+    name: 'Alpha Audiotronics, Inc.'
+
+  - value: 0x0352
+    name: 'iRiding(Xiamen)Technology Co.,Ltd.'
+
+  - value: 0x0351
+    name: 'Pieps GmbH'
+
+  - value: 0x0350
+    name: 'Bitstrata Systems Inc.'
+
+  - value: 0x034F
+    name: 'Heartland Payment Systems'
+
+  - value: 0x034E
+    name: 'SafeTrust Inc.'
+
+  - value: 0x034D
+    name: 'TASER International, Inc.'
+
+  - value: 0x034C
+    name: 'HM Electronics, Inc.'
+
+  - value: 0x034B
+    name: 'Libratone A/S'
+
+  - value: 0x034A
+    name: 'Vaddio'
+
+  - value: 0x0349
+    name: 'VersaMe'
+
+  - value: 0x0348
+    name: 'Arioneo'
+
+  - value: 0x0347
+    name: 'Prevent Biometrics'
+
+  - value: 0x0346
+    name: 'Acuity Brands Lighting, Inc'
+
+  - value: 0x0345
+    name: 'Locus Positioning'
+
+  - value: 0x0344
+    name: 'Whirl Inc'
+
+  - value: 0x0343
+    name: 'Drekker Development Pty. Ltd.'
+
+  - value: 0x0342
+    name: 'GERTEC BRASIL LTDA.'
+
+  - value: 0x0341
+    name: 'Etesian Technologies LLC'
+
+  - value: 0x0340
+    name: 'Letsense s.r.l.'
+
+  - value: 0x033F
+    name: 'Automation Components, Inc.'
+
+  - value: 0x033E
+    name: 'Monitra SA'
+
+  - value: 0x033D
+    name: 'TPV Technology Limited'
+
+  - value: 0x033C
+    name: 'Virtuosys'
+
+  - value: 0x033B
+    name: 'Courtney Thorne Limited'
+
+  - value: 0x033A
+    name: 'Appception, Inc.'
+
+  - value: 0x0339
+    name: 'Blue Sky Scientific, LLC'
+
+  - value: 0x0338
+    name: 'COBI GmbH'
+
+  - value: 0x0337
+    name: 'AJP2 Holdings, LLC'
+
+  - value: 0x0336
+    name: 'GISTIC'
+
+  - value: 0x0335
+    name: 'Enlighted Inc'
+
+  - value: 0x0334
+    name: 'Airthings ASA'
+
+  - value: 0x0333
+    name: 'Mul-T-Lock'
+
+  - value: 0x0332
+    name: 'Electrocompaniet A.S.'
+
+  - value: 0x0331
+    name: '3flares Technologies Inc.'
+
+  - value: 0x0330
+    name: 'North Pole Engineering'
+
+  - value: 0x032F
+    name: 'OttoQ Inc'
+
+  - value: 0x032E
+    name: 'indoormap'
+
+  - value: 0x032D
+    name: 'BM innovations GmbH'
+
+  - value: 0x032C
+    name: 'NIPPON SMT.CO.,Ltd'
+
+  - value: 0x032B
+    name: 'ESYLUX'
+
+  - value: 0x032A
+    name: 'Electronic Design Lab'
+
+  - value: 0x0329
+    name: 'Eargo, Inc.'
+
+  - value: 0x0328
+    name: 'Grundfos A/S'
+
+  - value: 0x0327
+    name: 'Essex Electronics'
+
+  - value: 0x0326
+    name: 'Healthwear Technologies (Changzhou)Ltd'
+
+  - value: 0x0325
+    name: 'Amotus Solutions'
+
+  - value: 0x0324
+    name: 'Astro, Inc.'
+
+  - value: 0x0323
+    name: 'Rotor Bike Components'
+
+  - value: 0x0322
+    name: 'Compumedics Limited'
+
+  - value: 0x0321
+    name: 'Jewelbots'
+
+  - value: 0x0320
+    name: 'SONO ELECTRONICS. CO., LTD'
+
+  - value: 0x031F
+    name: 'MetaSystem S.p.A.'
+
+  - value: 0x031E
+    name: 'Eyefi, Inc.'
+
+  - value: 0x031D
+    name: 'Enterlab ApS'
+
+  - value: 0x031C
+    name: 'Lab Sensor Solutions'
+
+  - value: 0x031B
+    name: 'HQ Inc'
+
+  - value: 0x031A
+    name: 'Wurth Elektronik eiSos GmbH & Co. KG'
+
+  - value: 0x0319
+    name: 'Eugster Frismag AG'
+
+  - value: 0x0318
+    name: 'Aspenta International'
+
+  - value: 0x0317
+    name: 'CHUO Electronics CO., LTD.'
+
+  - value: 0x0316
+    name: 'AG Measurematics Pvt. Ltd.'
+
+  - value: 0x0315
+    name: 'Thermo Fisher Scientific'
+
+  - value: 0x0314
+    name: 'RIIG AI Sp. z o.o.'
+
+  - value: 0x0313
+    name: 'DiveNav, Inc.'
+
+  - value: 0x0312
+    name: 'Ducere Technologies Pvt Ltd'
+
+  - value: 0x0311
+    name: 'PEEQ DATA'
+
+  - value: 0x0310
+    name: 'SGL Italia S.r.l.'
+
+  - value: 0x030F
+    name: 'Shortcut Labs'
+
+  - value: 0x030E
+    name: 'Deviceworx'
+
+  - value: 0x030D
+    name: 'Devdata S.r.l.'
+
+  - value: 0x030C
+    name: 'Hilti AG'
+
+  - value: 0x030B
+    name: 'Magnitude Lighting Converters'
+
+  - value: 0x030A
+    name: 'Ellisys'
+
+  - value: 0x0309
+    name: 'Dolby Labs'
+
+  - value: 0x0308
+    name: 'Surefire, LLC'
+
+  - value: 0x0307
+    name: 'FUJI INDUSTRIAL CO.,LTD.'
+
+  - value: 0x0306
+    name: 'Life Laboratory Inc.'
+
+  - value: 0x0305
+    name: 'Swipp ApS'
+
+  - value: 0x0304
+    name: 'Oura Health Ltd'
+
+  - value: 0x0303
+    name: 'IACA electronique'
+
+  - value: 0x0302
+    name: 'Loop Devices, Inc'
+
+  - value: 0x0301
+    name: 'Giatec Scientific Inc.'
+
+  - value: 0x0300
+    name: 'World Moto Inc.'
+
+  - value: 0x02FF
+    name: 'Silicon Laboratories'
+
+  - value: 0x02FE
+    name: 'Lierda Science & Technology Group Co., Ltd.'
+
+  - value: 0x02FD
+    name: 'Uwanna, Inc.'
+
+  - value: 0x02FC
+    name: 'Shanghai Frequen Microelectronics Co., Ltd.'
+
+  - value: 0x02FB
+    name: 'Clarius Mobile Health Corp.'
+
+  - value: 0x02FA
+    name: 'CoSTAR TEchnologies'
+
+  - value: 0x02F9
+    name: 'IMAGINATION TECHNOLOGIES LTD'
+
+  - value: 0x02F8
+    name: 'Runteq Oy Ltd'
+
+  - value: 0x02F7
+    name: 'DreamVisions co., Ltd.'
+
+  - value: 0x02F6
+    name: 'Intemo Technologies'
+
+  - value: 0x02F5
+    name: 'Indagem Tech LLC'
+
+  - value: 0x02F4
+    name: 'Vensi, Inc.'
+
+  - value: 0x02F3
+    name: 'AuthAir, Inc'
+
+  - value: 0x02F2
+    name: 'GoPro, Inc.'
+
+  - value: 0x02F1
+    name: 'The Idea Cave, LLC'
+
+  - value: 0x02F0
+    name: 'Blackrat Software'
+
+  - value: 0x02EF
+    name: 'SMART-INNOVATION.inc'
+
+  - value: 0x02EE
+    name: 'Citizen Holdings Co., Ltd.'
+
+  - value: 0x02ED
+    name: 'HTC Corporation'
+
+  - value: 0x02EC
+    name: 'Delta Systems, Inc'
+
+  - value: 0x02EB
+    name: 'Ardic Technology'
+
+  - value: 0x02EA
+    name: 'Fujitsu Limited'
+
+  - value: 0x02E9
+    name: 'Sensogram Technologies, Inc.'
+
+  - value: 0x02E8
+    name: 'American Music Environments'
+
+  - value: 0x02E7
+    name: 'Connected Yard, Inc.'
+
+  - value: 0x02E6
+    name: 'Unwire'
+
+  - value: 0x02E5
+    name: 'Espressif Systems (Shanghai) Co., Ltd.'
+
+  - value: 0x02E4
+    name: 'Bytestorm Ltd.'
+
+  - value: 0x02E3
+    name: 'Carmanah Technologies Corp.'
+
+  - value: 0x02E2
+    name: 'NTT docomo'
+
+  - value: 0x02E1
+    name: 'Victron Energy BV'
+
+  - value: 0x02E0
+    name: 'University of Michigan'
+
+  - value: 0x02DF
+    name: 'Blur Product Development'
+
+  - value: 0x02DE
+    name: 'Samsung SDS Co., Ltd.'
+
+  - value: 0x02DD
+    name: 'Flint Rehabilitation Devices, LLC'
+
+  - value: 0x02DC
+    name: 'DeWalch Technologies, Inc.'
+
+  - value: 0x02DB
+    name: 'Digi International Inc (R)'
+
+  - value: 0x02DA
+    name: 'Gilvader'
+
+  - value: 0x02D9
+    name: 'Fliegl Agrartechnik GmbH'
+
+  - value: 0x02D8
+    name: 'Neosfar'
+
+  - value: 0x02D7
+    name: 'NIPPON SYSTEMWARE CO.,LTD.'
+
+  - value: 0x02D6
+    name: 'Send Solutions'
+
+  - value: 0x02D5
+    name: 'OMRON Corporation'
+
+  - value: 0x02D4
+    name: 'Secuyou ApS'
+
+  - value: 0x02D3
+    name: 'Powercast Corporation'
+
+  - value: 0x02D2
+    name: 'Afero, Inc.'
+
+  - value: 0x02D1
+    name: 'Empatica Srl'
+
+  - value: 0x02D0
+    name: '3M'
+
+  - value: 0x02CF
+    name: 'Anima'
+
+  - value: 0x02CE
+    name: 'Teva Branded Pharmaceutical Products R&D, Inc.'
+
+  - value: 0x02CD
+    name: 'BMA ergonomics b.v.'
+
+  - value: 0x02CC
+    name: 'Eijkelkamp Soil & Water'
+
+  - value: 0x02CB
+    name: 'AINA-Wireless Inc.'
+
+  - value: 0x02CA
+    name: 'ABOV Semiconductor'
+
+  - value: 0x02C9
+    name: 'PayRange Inc.'
+
+  - value: 0x02C8
+    name: 'OneSpan'
+
+  - value: 0x02C7
+    name: 'Electronics Tomorrow Limited'
+
+  - value: 0x02C6
+    name: 'Ayatan Sensors'
+
+  - value: 0x02C5
+    name: 'Lenovo (Singapore) Pte Ltd.'
+
+  - value: 0x02C4
+    name: 'Wilson Sporting Goods'
+
+  - value: 0x02C3
+    name: 'Techtronic Power Tools Technology Limited'
+
+  - value: 0x02C2
+    name: 'Guillemot Corporation'
+
+  - value: 0x02C1
+    name: 'LINE Corporation'
+
+  - value: 0x02C0
+    name: 'Dash Robotics'
+
+  - value: 0x02BF
+    name: 'Redbird Flight Simulations'
+
+  - value: 0x02BE
+    name: 'Seguro Technology Sp. z o.o.'
+
+  - value: 0x02BD
+    name: 'Chemtronics'
+
+  - value: 0x02BC
+    name: 'Genevac Ltd'
+
+  - value: 0x02BB
+    name: 'Koha.,Co.Ltd'
+
+  - value: 0x02BA
+    name: 'Swissprime Technologies AG'
+
+  - value: 0x02B9
+    name: 'Rinnai Corporation'
+
+  - value: 0x02B8
+    name: 'Chrono Therapeutics'
+
+  - value: 0x02B7
+    name: 'Oort Technologies LLC'
+
+  - value: 0x02B6
+    name: 'Schneider Electric'
+
+  - value: 0x02B5
+    name: 'HANSHIN ELECTRIC RAILWAY CO.,LTD.'
+
+  - value: 0x02B4
+    name: 'Hyginex, Inc.'
+
+  - value: 0x02B3
+    name: 'CLABER S.P.A.'
+
+  - value: 0x02B2
+    name: 'Oura Health Oy'
+
+  - value: 0x02B1
+    name: 'Raden Inc'
+
+  - value: 0x02B0
+    name: 'Bestechnic(Shanghai),Ltd'
+
+  - value: 0x02AF
+    name: 'Technicolor USA Inc.'
+
+  - value: 0x02AE
+    name: 'WeatherFlow, Inc.'
+
+  - value: 0x02AD
+    name: 'Rx Networks, Inc.'
+
+  - value: 0x02AC
+    name: 'RTB Elektronik GmbH & Co. KG'
+
+  - value: 0x02AB
+    name: 'BBPOS Limited'
+
+  - value: 0x02AA
+    name: 'Doppler Lab'
+
+  - value: 0x02A9
+    name: 'Chargelib'
+
+  - value: 0x02A8
+    name: 'miSport Ltd.'
+
+  - value: 0x02A7
+    name: 'Illuxtron international B.V.'
+
+  - value: 0x02A6
+    name: 'Robert Bosch GmbH'
+
+  - value: 0x02A5
+    name: 'Tendyron Corporation'
+
+  - value: 0x02A4
+    name: 'Pacific Lock Company'
+
+  - value: 0x02A3
+    name: 'Itude'
+
+  - value: 0x02A2
+    name: 'Sera4 Ltd.'
+
+  - value: 0x02A1
+    name: 'InventureTrack Systems'
+
+  - value: 0x02A0
+    name: 'Impossible Camera GmbH'
+
+  - value: 0x029F
+    name: 'Areus Engineering GmbH'
+
+  - value: 0x029E
+    name: 'Kupson spol. s r.o.'
+
+  - value: 0x029D
+    name: 'ALOTTAZS LABS, LLC'
+
+  - value: 0x029C
+    name: 'Blue Sky Scientific, LLC'
+
+  - value: 0x029B
+    name: 'C2 Development, Inc.'
+
+  - value: 0x029A
+    name: 'Currant, Inc.'
+
+  - value: 0x0299
+    name: 'Inexess Technology Simma KG'
+
+  - value: 0x0298
+    name: 'EISST Ltd'
+
+  - value: 0x0297
+    name: 'storm power ltd'
+
+  - value: 0x0296
+    name: 'Petzl'
+
+  - value: 0x0295
+    name: 'Sivantos GmbH'
+
+  - value: 0x0294
+    name: 'ELIAS GmbH'
+
+  - value: 0x0293
+    name: 'Blue Bite'
+
+  - value: 0x0292
+    name: 'SwiftSensors'
+
+  - value: 0x0291
+    name: 'CliniCloud Inc'
+
+  - value: 0x0290
+    name: 'Multibit Oy'
+
+  - value: 0x028F
+    name: 'Church & Dwight Co., Inc'
+
+  - value: 0x028E
+    name: 'RF Digital Corp'
+
+  - value: 0x028D
+    name: 'IF, LLC'
+
+  - value: 0x028C
+    name: 'NANOLINK APS'
+
+  - value: 0x028B
+    name: 'Code Gears LTD'
+
+  - value: 0x028A
+    name: 'Jetro AS'
+
+  - value: 0x0289
+    name: 'SK Telecom'
+
+  - value: 0x0288
+    name: 'Willowbank Electronics Ltd'
+
+  - value: 0x0287
+    name: 'Wally Ventures S.L.'
+
+  - value: 0x0286
+    name: 'RF Code, Inc.'
+
+  - value: 0x0285
+    name: 'WOWTech Canada Ltd.'
+
+  - value: 0x0284
+    name: 'Synapse Electronics'
+
+  - value: 0x0283
+    name: 'Maven Machines, Inc.'
+
+  - value: 0x0282
+    name: 'Sonova AG'
+
+  - value: 0x0281
+    name: 'StoneL'
+
+  - value: 0x0280
+    name: 'ITEC corporation'
+
+  - value: 0x027F
+    name: 'ruwido austria gmbh'
+
+  - value: 0x027E
+    name: 'HabitAware, LLC'
+
+  - value: 0x027D
+    name: 'HUAWEI Technologies Co., Ltd.'
+
+  - value: 0x027C
+    name: 'Aseptika Ltd'
+
+  - value: 0x027B
+    name: 'DEFA AS'
+
+  - value: 0x027A
+    name: 'Ekomini inc.'
+
+  - value: 0x0279
+    name: 'steute Schaltgerate GmbH & Co. KG'
+
+  - value: 0x0278
+    name: 'Johnson Outdoors Inc'
+
+  - value: 0x0277
+    name: 'bewhere inc'
+
+  - value: 0x0276
+    name: 'E.G.O. Elektro-Geraetebau GmbH'
+
+  - value: 0x0275
+    name: 'Geotab'
+
+  - value: 0x0274
+    name: 'Motsai Research'
+
+  - value: 0x0273
+    name: 'OCEASOFT'
+
+  - value: 0x0272
+    name: 'Alps Alpine Co., Ltd.'
+
+  - value: 0x0271
+    name: 'Animas Corp'
+
+  - value: 0x0270
+    name: 'LSI ADL Technology'
+
+  - value: 0x026F
+    name: 'Aptcode Solutions'
+
+  - value: 0x026E
+    name: 'FLEURBAEY BVBA'
+
+  - value: 0x026D
+    name: 'Technogym SPA'
+
+  - value: 0x026C
+    name: 'Domster Tadeusz Szydlowski'
+
+  - value: 0x026B
+    name: 'DEKA Research & Development Corp.'
+
+  - value: 0x026A
+    name: 'Gemalto'
+
+  - value: 0x0269
+    name: 'Torrox GmbH & Co KG'
+
+  - value: 0x0268
+    name: 'Cerevo'
+
+  - value: 0x0267
+    name: 'XMI Systems SA'
+
+  - value: 0x0266
+    name: 'Schawbel Technologies LLC'
+
+  - value: 0x0265
+    name: 'SMK Corporation'
+
+  - value: 0x0264
+    name: 'DDS, Inc.'
+
+  - value: 0x0263
+    name: 'Identiv, Inc.'
+
+  - value: 0x0262
+    name: 'Glacial Ridge Technologies'
+
+  - value: 0x0261
+    name: 'SECVRE GmbH'
+
+  - value: 0x0260
+    name: 'SensaRx'
+
+  - value: 0x025F
+    name: 'Yardarm Technologies'
+
+  - value: 0x025E
+    name: 'Fluke Corporation'
+
+  - value: 0x025D
+    name: 'Lexmark International Inc.'
+
+  - value: 0x025C
+    name: 'NetEase（Hangzhou）Network co.Ltd.'
+
+  - value: 0x025B
+    name: 'Five Interactive, LLC dba Zendo'
+
+  - value: 0x025A
+    name: 'University of Applied Sciences Valais/Haute Ecole Valaisanne'
+
+  - value: 0x0259
+    name: 'ALTYOR'
+
+  - value: 0x0258
+    name: 'Devialet SA'
+
+  - value: 0x0257
+    name: 'AdBabble Local Commerce Inc.'
+
+  - value: 0x0256
+    name: 'G24 Power Limited'
+
+  - value: 0x0255
+    name: 'Dai Nippon Printing Co., Ltd.'
+
+  - value: 0x0254
+    name: 'Playbrush'
+
+  - value: 0x0253
+    name: 'Xicato Inc.'
+
+  - value: 0x0252
+    name: 'UKC Technosolution'
+
+  - value: 0x0251
+    name: 'Lumo Bodytech Inc.'
+
+  - value: 0x0250
+    name: 'Sapphire Circuits LLC'
+
+  - value: 0x024F
+    name: 'Schneider Schreibgeräte GmbH'
+
+  - value: 0x024E
+    name: 'Microtronics Engineering GmbH'
+
+  - value: 0x024D
+    name: 'M-Way Solutions GmbH'
+
+  - value: 0x024C
+    name: 'Blue Clover Devices'
+
+  - value: 0x024B
+    name: 'Orlan LLC'
+
+  - value: 0x024A
+    name: 'Uwatec AG'
+
+  - value: 0x0249
+    name: 'Transcranial Ltd'
+
+  - value: 0x0248
+    name: 'Parker Hannifin Corp'
+
+  - value: 0x0247
+    name: 'FiftyThree Inc.'
+
+  - value: 0x0246
+    name: 'ACKme Networks, Inc.'
+
+  - value: 0x0245
+    name: 'Endress+Hauser'
+
+  - value: 0x0244
+    name: 'Iotera Inc'
+
+  - value: 0x0243
+    name: 'Masimo Corp'
+
+  - value: 0x0242
+    name: '16Lab Inc'
+
+  - value: 0x0241
+    name: 'Bragi GmbH'
+
+  - value: 0x0240
+    name: 'Argenox Technologies'
+
+  - value: 0x023F
+    name: 'WaveWare Technologies Inc.'
+
+  - value: 0x023E
+    name: 'Raven Industries'
+
+  - value: 0x023D
+    name: 'ViCentra B.V.'
+
+  - value: 0x023C
+    name: 'Awarepoint'
+
+  - value: 0x023B
+    name: 'Beijing CarePulse Electronic Technology Co, Ltd'
+
+  - value: 0x023A
+    name: 'Alatech Tehnology'
+
+  - value: 0x0239
+    name: 'JIN CO, Ltd'
+
+  - value: 0x0238
+    name: 'Trakm8 Ltd'
+
+  - value: 0x0237
+    name: 'MSHeli s.r.l.'
+
+  - value: 0x0236
+    name: 'Pitpatpet Ltd'
+
+  - value: 0x0235
+    name: 'Qrio Inc'
+
+  - value: 0x0234
+    name: 'FengFan (BeiJing) Technology Co, Ltd'
+
+  - value: 0x0233
+    name: 'Shenzhen SuLong Communication Ltd'
+
+  - value: 0x0232
+    name: 'x-Senso Solutions Kft'
+
+  - value: 0x0231
+    name: 'ETA SA'
+
+  - value: 0x0230
+    name: 'Foster Electric Company, Ltd'
+
+  - value: 0x022F
+    name: 'Huami (Shanghai) Culture Communication CO., LTD'
+
+  - value: 0x022E
+    name: 'Siemens AG'
+
+  - value: 0x022D
+    name: 'Lupine'
+
+  - value: 0x022C
+    name: 'Pharynks Corporation'
+
+  - value: 0x022B
+    name: 'Tesla, Inc.'
+
+  - value: 0x022A
+    name: 'Stamer Musikanlagen GMBH'
+
+  - value: 0x0229
+    name: 'Muoverti Limited'
+
+  - value: 0x0228
+    name: 'Twocanoes Labs, LLC'
+
+  - value: 0x0227
+    name: 'LifeBEAM Technologies'
+
+  - value: 0x0226
+    name: 'Merlinia A/S'
+
+  - value: 0x0225
+    name: 'Nestlé Nespresso S.A.'
+
+  - value: 0x0224
+    name: 'Comarch SA'
+
+  - value: 0x0223
+    name: 'Philip Morris Products S.A.'
+
+  - value: 0x0222
+    name: 'Praxis Dynamics'
+
+  - value: 0x0221
+    name: 'Mobiquity Networks Inc'
+
+  - value: 0x0220
+    name: 'Manus Machina BV'
+
+  - value: 0x021F
+    name: 'Luster Leaf Products  Inc'
+
+  - value: 0x021E
+    name: 'Goodnet, Ltd'
+
+  - value: 0x021D
+    name: 'Edamic'
+
+  - value: 0x021C
+    name: 'Mobicomm Inc'
+
+  - value: 0x021B
+    name: 'Cisco Systems, Inc'
+
+  - value: 0x021A
+    name: 'Blue Speck Labs, LLC'
+
+  - value: 0x0219
+    name: 'DOTT Limited'
+
+  - value: 0x0218
+    name: 'Hiotech AB'
+
+  - value: 0x0217
+    name: 'Tech4home, Lda'
+
+  - value: 0x0216
+    name: 'MTI Ltd'
+
+  - value: 0x0215
+    name: 'Lukoton Experience Oy'
+
+  - value: 0x0214
+    name: 'IK Multimedia Production srl'
+
+  - value: 0x0213
+    name: 'Wyler AG'
+
+  - value: 0x0212
+    name: 'Interplan Co., Ltd'
+
+  - value: 0x0211
+    name: 'Telink Semiconductor Co. Ltd'
+
+  - value: 0x0210
+    name: 'ikeGPS'
+
+  - value: 0x020F
+    name: 'Comodule GMBH'
+
+  - value: 0x020E
+    name: 'Omron Healthcare Co., LTD'
+
+  - value: 0x020D
+    name: 'Simplo Technology Co., LTD'
+
+  - value: 0x020C
+    name: 'CoroWare Technologies, Inc'
+
+  - value: 0x020B
+    name: 'Jaguar Land Rover Limited'
+
+  - value: 0x020A
+    name: 'Macnica Inc.'
+
+  - value: 0x0209
+    name: 'InvisionHeart Inc.'
+
+  - value: 0x0208
+    name: 'LumiGeek LLC'
+
+  - value: 0x0207
+    name: 'STEMP Inc.'
+
+  - value: 0x0206
+    name: 'Otter Products, LLC'
+
+  - value: 0x0205
+    name: 'Smartbotics Inc.'
+
+  - value: 0x0204
+    name: 'Tapcentive Inc.'
+
+  - value: 0x0203
+    name: 'Kemppi Oy'
+
+  - value: 0x0202
+    name: 'Rigado LLC'
+
+  - value: 0x0201
+    name: 'AR Timing'
+
+  - value: 0x0200
+    name: 'Verifone Systems Pte Ltd. Taiwan Branch'
+
+  - value: 0x01FF
+    name: 'Freescale Semiconductor, Inc.'
+
+  - value: 0x01FE
+    name: 'Radio Systems Corporation'
+
+  - value: 0x01FD
+    name: 'Kontakt Micro-Location Sp. z o.o.'
+
+  - value: 0x01FC
+    name: 'Wahoo Fitness, LLC'
+
+  - value: 0x01FB
+    name: 'Form Lifting, LLC'
+
+  - value: 0x01FA
+    name: 'Gozio Inc.'
+
+  - value: 0x01F9
+    name: 'Medtronic Inc.'
+
+  - value: 0x01F8
+    name: 'Anyka (Guangzhou) Microelectronics Technology Co, LTD'
+
+  - value: 0x01F7
+    name: 'Gelliner Limited'
+
+  - value: 0x01F6
+    name: 'DJO Global'
+
+  - value: 0x01F5
+    name: 'Cool Webthings Limited'
+
+  - value: 0x01F4
+    name: 'UTC Fire and Security'
+
+  - value: 0x01F3
+    name: 'The University of Tokyo'
+
+  - value: 0x01F2
+    name: 'Itron, Inc.'
+
+  - value: 0x01F1
+    name: 'Zebra Technologies Corporation'
+
+  - value: 0x01F0
+    name: 'KloudNation'
+
+  - value: 0x01EF
+    name: 'Fullpower Technologies, Inc.'
+
+  - value: 0x01EE
+    name: 'Valeo Service'
+
+  - value: 0x01ED
+    name: 'CuteCircuit LTD'
+
+  - value: 0x01EC
+    name: 'Spreadtrum Communications Shanghai Ltd'
+
+  - value: 0x01EB
+    name: 'AutoMap LLC'
+
+  - value: 0x01EA
+    name: 'Advanced Application Design, Inc.'
+
+  - value: 0x01E9
+    name: 'Sano, Inc.'
+
+  - value: 0x01E8
+    name: 'STIR'
+
+  - value: 0x01E7
+    name: 'IPS Group Inc.'
+
+  - value: 0x01E6
+    name: 'Technology Solutions (UK) Ltd'
+
+  - value: 0x01E5
+    name: 'Dynamic Devices Ltd'
+
+  - value: 0x01E4
+    name: 'Freedom Innovations'
+
+  - value: 0x01E3
+    name: 'Caterpillar Inc'
+
+  - value: 0x01E2
+    name: 'Lectronix, Inc.'
+
+  - value: 0x01E1
+    name: 'Jolla Ltd'
+
+  - value: 0x01E0
+    name: 'Widex A/S'
+
+  - value: 0x01DF
+    name: 'Bison Group Ltd.'
+
+  - value: 0x01DE
+    name: 'Minelab Electronics Pty Limited'
+
+  - value: 0x01DD
+    name: 'Koninklijke Philips N.V.'
+
+  - value: 0x01DC
+    name: 'iParking Ltd.'
+
+  - value: 0x01DB
+    name: 'Innblue Consulting'
+
+  - value: 0x01DA
+    name: 'Logitech International SA'
+
+  - value: 0x01D9
+    name: 'Savant Systems LLC'
+
+  - value: 0x01D8
+    name: 'Code Corporation'
+
+  - value: 0x01D7
+    name: 'Squadrone Systems Inc.'
+
+  - value: 0x01D6
+    name: 'G-wearables inc.'
+
+  - value: 0x01D5
+    name: 'ELAD srl'
+
+  - value: 0x01D4
+    name: 'Newlab S.r.l.'
+
+  - value: 0x01D3
+    name: 'Sky Wave Design'
+
+  - value: 0x01D2
+    name: 'Gill Electronics'
+
+  - value: 0x01D1
+    name: 'August Home, Inc'
+
+  - value: 0x01D0
+    name: 'Primus Inter Pares Ltd'
+
+  - value: 0x01CF
+    name: 'BSH'
+
+  - value: 0x01CE
+    name: 'HOUWA SYSTEM DESIGN, k.k.'
+
+  - value: 0x01CD
+    name: 'Chengdu Synwing Technology Ltd'
+
+  - value: 0x01CC
+    name: 'Sam Labs Ltd.'
+
+  - value: 0x01CB
+    name: 'Fetch My Pet'
+
+  - value: 0x01CA
+    name: 'Laerdal Medical AS'
+
+  - value: 0x01C9
+    name: 'Avi-on'
+
+  - value: 0x01C8
+    name: 'Poly-Control ApS'
+
+  - value: 0x01C7
+    name: 'Abiogenix Inc.'
+
+  - value: 0x01C6
+    name: 'HASWARE Inc.'
+
+  - value: 0x01C5
+    name: 'Bitcraze AB'
+
+  - value: 0x01C4
+    name: 'DME Microelectronics'
+
+  - value: 0x01C3
+    name: 'Bunch'
+
+  - value: 0x01C2
+    name: 'Transenergooil AG'
+
+  - value: 0x01C1
+    name: 'BRADATECH Corp.'
+
+  - value: 0x01C0
+    name: 'pironex GmbH'
+
+  - value: 0x01BF
+    name: 'Hongkong OnMicro Electronics Limited'
+
+  - value: 0x01BE
+    name: 'Pulsate Mobile Ltd.'
+
+  - value: 0x01BD
+    name: 'Syszone Co., Ltd'
+
+  - value: 0x01BC
+    name: 'SenionLab AB'
+
+  - value: 0x01BB
+    name: 'Cochlear Bone Anchored Solutions AB'
+
+  - value: 0x01BA
+    name: 'Stages Cycling LLC'
+
+  - value: 0x01B9
+    name: 'HANA Micron'
+
+  - value: 0x01B8
+    name: 'i+D3 S.L.'
+
+  - value: 0x01B7
+    name: 'General Electric Company'
+
+  - value: 0x01B6
+    name: 'LM Technologies Ltd'
+
+  - value: 0x01B5
+    name: 'Nest Labs Inc.'
+
+  - value: 0x01B4
+    name: 'Trineo Sp. z o.o.'
+
+  - value: 0x01B3
+    name: 'Nytec, Inc.'
+
+  - value: 0x01B2
+    name: 'Nymi Inc.'
+
+  - value: 0x01B1
+    name: 'Netizens Sp. z o.o.'
+
+  - value: 0x01B0
+    name: 'Star Micronics Co., Ltd.'
+
+  - value: 0x01AF
+    name: 'Sunrise Micro Devices, Inc.'
+
+  - value: 0x01AE
+    name: 'Earlens Corporation'
+
+  - value: 0x01AD
+    name: 'FlightSafety International'
+
+  - value: 0x01AC
+    name: 'Trividia Health, Inc.'
+
+  - value: 0x01AB
+    name: 'Meta Platforms, Inc.'
+
+  - value: 0x01AA
+    name: 'Geophysical Technology Inc.'
+
+  - value: 0x01A9
+    name: 'Canon Inc.'
+
+  - value: 0x01A8
+    name: 'Taobao'
+
+  - value: 0x01A7
+    name: 'ENERGOUS CORPORATION'
+
+  - value: 0x01A6
+    name: 'Wille Engineering'
+
+  - value: 0x01A5
+    name: 'Icon Health and Fitness'
+
+  - value: 0x01A4
+    name: 'MSA Innovation, LLC'
+
+  - value: 0x01A3
+    name: 'EROAD'
+
+  - value: 0x01A2
+    name: 'GIGALANE.CO.,LTD'
+
+  - value: 0x01A1
+    name: 'FIAMM'
+
+  - value: 0x01A0
+    name: 'Channel Enterprises (HK) Ltd.'
+
+  - value: 0x019F
+    name: 'Strainstall Ltd'
+
+  - value: 0x019E
+    name: 'Ceruus'
+
+  - value: 0x019D
+    name: 'CVS Health'
+
+  - value: 0x019C
+    name: 'Cokiya Incorporated'
+
+  - value: 0x019B
+    name: 'CUBETECH s.r.o.'
+
+  - value: 0x019A
+    name: 'TRON Forum'
+
+  - value: 0x0199
+    name: 'SALTO SYSTEMS S.L.'
+
+  - value: 0x0198
+    name: 'VENGIT Korlatolt Felelossegu Tarsasag'
+
+  - value: 0x0197
+    name: 'WiSilica Inc.'
+
+  - value: 0x0196
+    name: 'Paxton Access Ltd'
+
+  - value: 0x0195
+    name: 'Zuli'
+
+  - value: 0x0194
+    name: 'Acoustic Stream Corporation'
+
+  - value: 0x0193
+    name: 'Maveric Automation LLC'
+
+  - value: 0x0192
+    name: 'Cloudleaf, Inc'
+
+  - value: 0x0191
+    name: 'FDK CORPORATION'
+
+  - value: 0x0190
+    name: 'Intelletto Technologies Inc.'
+
+  - value: 0x018F
+    name: 'Fireflies Systems'
+
+  - value: 0x018E
+    name: 'Google LLC'
+
+  - value: 0x018D
+    name: 'Extron Design Services'
+
+  - value: 0x018C
+    name: 'Wilo SE'
+
+  - value: 0x018B
+    name: 'Konica Minolta, Inc.'
+
+  - value: 0x018A
+    name: 'Able Trend Technology Limited'
+
+  - value: 0x0189
+    name: 'Physical Enterprises Inc.'
+
+  - value: 0x0188
+    name: 'Unico RBC'
+
+  - value: 0x0187
+    name: 'Seraphim Sense Ltd'
+
+  - value: 0x0186
+    name: 'CORE Lighting Ltd'
+
+  - value: 0x0185
+    name: "bel'apps LLC"
+
+  - value: 0x0184
+    name: 'Nectar'
+
+  - value: 0x0183
+    name: 'Walt Disney'
+
+  - value: 0x0182
+    name: 'HOP Ubiquitous'
+
+  - value: 0x0181
+    name: 'Gecko Health Innovations, Inc.'
+
+  - value: 0x0180
+    name: 'Gigaset Technologies GmbH'
+
+  - value: 0x017F
+    name: 'XTel Wireless ApS'
+
+  - value: 0x017E
+    name: 'BluDotz Ltd'
+
+  - value: 0x017D
+    name: 'BatAndCat'
+
+  - value: 0x017C
+    name: 'Mercedes-Benz Group AG'
+
+  - value: 0x017B
+    name: 'taskit GmbH'
+
+  - value: 0x017A
+    name: 'Telemonitor, Inc.'
+
+  - value: 0x0179
+    name: 'LAPIS Semiconductor Co.,Ltd'
+
+  - value: 0x0178
+    name: 'CASIO COMPUTER CO., LTD.'
+
+  - value: 0x0177
+    name: 'I-SYST inc.'
+
+  - value: 0x0176
+    name: 'SentriLock'
+
+  - value: 0x0175
+    name: 'Dynamic Controls'
+
+  - value: 0x0174
+    name: 'Everykey Inc.'
+
+  - value: 0x0173
+    name: 'Kocomojo, LLC'
+
+  - value: 0x0172
+    name: 'Connovate Technology Private Limited'
+
+  - value: 0x0171
+    name: 'Amazon.com Services LLC'
+
+  - value: 0x0170
+    name: 'Roche Diabetes Care AG'
+
+  - value: 0x016F
+    name: 'Podo Labs, Inc'
+
+  - value: 0x016E
+    name: 'Volantic AB'
+
+  - value: 0x016D
+    name: 'LifeScan Inc'
+
+  - value: 0x016C
+    name: 'MYSPHERA'
+
+  - value: 0x016B
+    name: 'Qblinks'
+
+  - value: 0x016A
+    name: 'Copeland Cold Chain LP'
+
+  - value: 0x0169
+    name: 'emberlight'
+
+  - value: 0x0168
+    name: 'Spicebox LLC'
+
+  - value: 0x0167
+    name: 'Ascensia Diabetes Care US Inc.'
+
+  - value: 0x0166
+    name: 'MISHIK Pte Ltd'
+
+  - value: 0x0165
+    name: 'Milwaukee Electric Tools'
+
+  - value: 0x0164
+    name: 'Qingdao Yeelink Information Technology Co., Ltd.'
+
+  - value: 0x0163
+    name: 'PCH International'
+
+  - value: 0x0162
+    name: 'MADSGlobalNZ Ltd.'
+
+  - value: 0x0161
+    name: 'yikes'
+
+  - value: 0x0160
+    name: 'AwoX'
+
+  - value: 0x015F
+    name: 'Timer Cap Co.'
+
+  - value: 0x015E
+    name: 'Unikey Technologies, Inc.'
+
+  - value: 0x015D
+    name: 'Estimote, Inc.'
+
+  - value: 0x015C
+    name: 'Pitius Tec S.L.'
+
+  - value: 0x015B
+    name: 'Biomedical Research Ltd.'
+
+  - value: 0x015A
+    name: 'micas AG'
+
+  - value: 0x0159
+    name: 'ChefSteps, Inc.'
+
+  - value: 0x0158
+    name: 'Inmite s.r.o.'
+
+  - value: 0x0157
+    name: 'Anhui Huami Information Technology Co., Ltd.'
+
+  - value: 0x0156
+    name: 'Accumulate AB'
+
+  - value: 0x0155
+    name: 'NETATMO'
+
+  - value: 0x0154
+    name: 'Pebble Technology'
+
+  - value: 0x0153
+    name: 'ROL Ergo'
+
+  - value: 0x0152
+    name: 'Vernier Software & Technology'
+
+  - value: 0x0151
+    name: 'OnBeep'
+
+  - value: 0x0150
+    name: 'Pioneer Corporation'
+
+  - value: 0x014F
+    name: 'B&W Group Ltd.'
+
+  - value: 0x014E
+    name: 'Tangerine, Inc.'
+
+  - value: 0x014D
+    name: 'HUIZHOU DESAY SV AUTOMOTIVE CO., LTD.'
+
+  - value: 0x014C
+    name: 'Mesh-Net Ltd'
+
+  - value: 0x014B
+    name: 'Master Lock'
+
+  - value: 0x014A
+    name: 'Tivoli Audio, LLC'
+
+  - value: 0x0149
+    name: 'Perytons Ltd.'
+
+  - value: 0x0148
+    name: 'Ambimat Electronics'
+
+  - value: 0x0147
+    name: 'Mighty Cast, Inc.'
+
+  - value: 0x0146
+    name: 'Ciright'
+
+  - value: 0x0145
+    name: 'Novatel Wireless'
+
+  - value: 0x0144
+    name: 'Lintech GmbH'
+
+  - value: 0x0143
+    name: 'Bkon Connect'
+
+  - value: 0x0142
+    name: 'Grape Systems Inc.'
+
+  - value: 0x0141
+    name: 'FedEx Services'
+
+  - value: 0x0140
+    name: 'Alpine Electronics (China) Co., Ltd'
+
+  - value: 0x013F
+    name: 'B&B Manufacturing Company'
+
+  - value: 0x013E
+    name: 'Nod, Inc.'
+
+  - value: 0x013D
+    name: 'WirelessWERX'
+
+  - value: 0x013C
+    name: 'Murata Manufacturing Co., Ltd.'
+
+  - value: 0x013B
+    name: 'Allegion'
+
+  - value: 0x013A
+    name: 'Tencent Holdings Ltd.'
+
+  - value: 0x0139
+    name: 'Focus Systems Corporation'
+
+  - value: 0x0138
+    name: 'NTEO Inc.'
+
+  - value: 0x0137
+    name: 'Prestigio Plaza Ltd.'
+
+  - value: 0x0136
+    name: 'Silvair, Inc.'
+
+  - value: 0x0135
+    name: 'Aireware LLC'
+
+  - value: 0x0134
+    name: 'Resolution Products, Ltd.'
+
+  - value: 0x0133
+    name: 'Blue Maestro Limited'
+
+  - value: 0x0132
+    name: 'MADS Inc'
+
+  - value: 0x0131
+    name: 'Cypress Semiconductor'
+
+  - value: 0x0130
+    name: 'Warehouse Innovations'
+
+  - value: 0x012F
+    name: 'Clarion Co. Inc.'
+
+  - value: 0x012E
+    name: 'ASSA ABLOY'
+
+  - value: 0x012D
+    name: 'Sony Corporation'
+
+  - value: 0x012C
+    name: 'TEMEC Instruments B.V.'
+
+  - value: 0x012B
+    name: 'SportIQ'
+
+  - value: 0x012A
+    name: 'Changzhou Yongse Infotech  Co., Ltd.'
+
+  - value: 0x0129
+    name: 'Nimble Devices Oy'
+
+  - value: 0x0128
+    name: 'GPSI Group Pty Ltd'
+
+  - value: 0x0127
+    name: 'Salutica Allied Solutions'
+
+  - value: 0x0126
+    name: 'Promethean Ltd.'
+
+  - value: 0x0125
+    name: 'SEAT es'
+
+  - value: 0x0124
+    name: 'HID Global'
+
+  - value: 0x0123
+    name: 'Kinsa, Inc'
+
+  - value: 0x0122
+    name: 'AirTurn, Inc.'
+
+  - value: 0x0121
+    name: 'Sino Wealth Electronic Ltd.'
+
+  - value: 0x0120
+    name: 'Porsche AG'
+
+  - value: 0x011F
+    name: 'Volkswagen AG'
+
+  - value: 0x011E
+    name: 'Skoda Auto a.s.'
+
+  - value: 0x011D
+    name: 'Arendi AG'
+
+  - value: 0x011C
+    name: 'Baidu'
+
+  - value: 0x011B
+    name: 'Hewlett Packard Enterprise'
+
+  - value: 0x011A
+    name: 'Qualcomm Labs, Inc.'
+
+  - value: 0x0119
+    name: 'Wize Technology Co., Ltd.'
+
+  - value: 0x0118
+    name: 'Radius Networks, Inc.'
+
+  - value: 0x0117
+    name: 'Wimoto Technologies Inc'
+
+  - value: 0x0116
+    name: '10AK Technologies'
+
+  - value: 0x0115
+    name: 'e.solutions'
+
+  - value: 0x0114
+    name: 'Xensr'
+
+  - value: 0x0113
+    name: 'Openbrain Technologies, Co., Ltd.'
+
+  - value: 0x0112
+    name: 'Visybl Inc.'
+
+  - value: 0x0111
+    name: 'Steelseries ApS'
+
+  - value: 0x0110
+    name: 'Nippon Seiki Co., Ltd.'
+
+  - value: 0x010F
+    name: 'HiSilicon Technologies CO., LIMITED'
+
+  - value: 0x010E
+    name: 'Audi AG'
+
+  - value: 0x010D
+    name: 'DENSO TEN Limited'
+
+  - value: 0x010C
+    name: 'Transducers Direct, LLC'
+
+  - value: 0x010B
+    name: 'ERi, Inc'
+
+  - value: 0x010A
+    name: 'Codegate Ltd'
+
+  - value: 0x0109
+    name: 'Atus BV'
+
+  - value: 0x0108
+    name: 'Chicony Electronics Co., Ltd.'
+
+  - value: 0x0107
+    name: 'Demant A/S'
+
+  - value: 0x0106
+    name: 'Innovative Yachtter Solutions'
+
+  - value: 0x0105
+    name: 'Ubiquitous Computing Technology Corporation'
+
+  - value: 0x0104
+    name: 'PLUS Location Systems Pty Ltd'
+
+  - value: 0x0103
+    name: 'Bang & Olufsen A/S'
+
+  - value: 0x0102
+    name: 'Keiser Corporation'
+
+  - value: 0x0101
+    name: 'Fugoo, Inc.'
+
+  - value: 0x0100
+    name: 'TomTom International BV'
+
+  - value: 0x00FF
+    name: 'Typo Products, LLC'
+
+  - value: 0x00FE
+    name: 'Stanley Black and Decker'
+
+  - value: 0x00FD
+    name: 'ValenceTech Limited'
+
+  - value: 0x00FC
+    name: 'Delphi Corporation'
+
+  - value: 0x00FB
+    name: 'KOUKAAM a.s.'
+
+  - value: 0x00FA
+    name: 'Crystal Alarm AB'
+
+  - value: 0x00F9
+    name: 'StickNFind'
+
+  - value: 0x00F8
+    name: 'AceUni Corp., Ltd.'
+
+  - value: 0x00F7
+    name: 'VSN Technologies, Inc.'
+
+  - value: 0x00F6
+    name: 'Elcometer Limited'
+
+  - value: 0x00F5
+    name: 'Smartifier Oy'
+
+  - value: 0x00F4
+    name: 'Nautilus Inc.'
+
+  - value: 0x00F3
+    name: 'Kent Displays Inc.'
+
+  - value: 0x00F2
+    name: 'Morse Project Inc.'
+
+  - value: 0x00F1
+    name: 'Witron Technology Limited'
+
+  - value: 0x00F0
+    name: 'PayPal, Inc.'
+
+  - value: 0x00EF
+    name: 'Bitsplitters GmbH'
+
+  - value: 0x00EE
+    name: 'Above Average Outcomes, Inc.'
+
+  - value: 0x00ED
+    name: 'Jolly Logic, LLC'
+
+  - value: 0x00EC
+    name: 'BioResearch Associates'
+
+  - value: 0x00EB
+    name: 'Server Technology Inc.'
+
+  - value: 0x00EA
+    name: 'Nielsen-Kellerman'
+
+  - value: 0x00E9
+    name: 'Vtrack Systems'
+
+  - value: 0x00E8
+    name: 'ACTS Technologies'
+
+  - value: 0x00E7
+    name: 'KS Technologies'
+
+  - value: 0x00E6
+    name: 'Freshtemp'
+
+  - value: 0x00E5
+    name: 'Eden Software Consultants Ltd.'
+
+  - value: 0x00E4
+    name: 'L.S. Research, Inc.'
+
+  - value: 0x00E3
+    name: 'inMusic Brands, Inc'
+
+  - value: 0x00E2
+    name: 'Semilink Inc'
+
+  - value: 0x00E1
+    name: 'Danlers Ltd'
+
+  - value: 0x00E0
+    name: 'Google'
+
+  - value: 0x00DF
+    name: 'Misfit Wearables Corp'
+
+  - value: 0x00DE
+    name: 'Muzik LLC'
+
+  - value: 0x00DD
+    name: 'Hosiden Corporation'
+
+  - value: 0x00DC
+    name: 'Procter & Gamble'
+
+  - value: 0x00DB
+    name: 'Snuza (Pty) Ltd'
+
+  - value: 0x00DA
+    name: 'txtr GmbH'
+
+  - value: 0x00D9
+    name: 'Voyetra Turtle Beach'
+
+  - value: 0x00D8
+    name: 'Qualcomm Connected Experiences, Inc.'
+
+  - value: 0x00D7
+    name: 'Qualcomm Technologies, Inc.'
+
+  - value: 0x00D6
+    name: 'Timex Group USA, Inc.'
+
+  - value: 0x00D5
+    name: 'Austco Communication Systems'
+
+  - value: 0x00D4
+    name: 'Kawantech'
+
+  - value: 0x00D3
+    name: 'Taixingbang Technology (HK) Co,. LTD.'
+
+  - value: 0x00D2
+    name: 'Renesas Design Netherlands B.V.'
+
+  - value: 0x00D1
+    name: 'Polar Electro Europe B.V.'
+
+  - value: 0x00D0
+    name: 'Dexcom, Inc.'
+
+  - value: 0x00CF
+    name: 'ARCHOS SA'
+
+  - value: 0x00CE
+    name: 'Eve Systems GmbH'
+
+  - value: 0x00CD
+    name: 'Microchip Technology Inc.'
+
+  - value: 0x00CC
+    name: 'Beats Electronics'
+
+  - value: 0x00CB
+    name: 'Binauric SE'
+
+  - value: 0x00CA
+    name: 'MC10'
+
+  - value: 0x00C9
+    name: 'Evluma'
+
+  - value: 0x00C8
+    name: 'GeLo Inc'
+
+  - value: 0x00C7
+    name: 'Quuppa Oy.'
+
+  - value: 0x00C6
+    name: 'Selfly BV'
+
+  - value: 0x00C5
+    name: 'Onset Computer Corporation'
+
+  - value: 0x00C4
+    name: 'LG Electronics'
+
+  - value: 0x00C3
+    name: 'adidas AG'
+
+  - value: 0x00C2
+    name: 'Geneq Inc.'
+
+  - value: 0x00C1
+    name: 'Shenzhen Excelsecu Data Technology Co.,Ltd'
+
+  - value: 0x00C0
+    name: 'AMICCOM Electronics Corporation'
+
+  - value: 0x00BF
+    name: 'Stalmart Technology Limited'
+
+  - value: 0x00BE
+    name: 'AAMP of America'
+
+  - value: 0x00BD
+    name: 'Aplix Corporation'
+
+  - value: 0x00BC
+    name: 'Ace Sensor Inc'
+
+  - value: 0x00BB
+    name: 'S-Power Electronics Limited'
+
+  - value: 0x00BA
+    name: 'Starkey Hearing Technologies'
+
+  - value: 0x00B9
+    name: 'Johnson Controls, Inc.'
+
+  - value: 0x00B8
+    name: 'Qualcomm Innovation Center, Inc. (QuIC)'
+
+  - value: 0x00B7
+    name: 'TreLab Ltd'
+
+  - value: 0x00B6
+    name: 'Meso international'
+
+  - value: 0x00B5
+    name: 'Swirl Networks'
+
+  - value: 0x00B4
+    name: 'BDE Technology Co., Ltd.'
+
+  - value: 0x00B3
+    name: 'Clarinox Technologies Pty. Ltd.'
+
+  - value: 0x00B2
+    name: 'Bekey A/S'
+
+  - value: 0x00B1
+    name: 'Saris Cycling Group, Inc'
+
+  - value: 0x00B0
+    name: 'Passif Semiconductor Corp'
+
+  - value: 0x00AF
+    name: 'Cinetix'
+
+  - value: 0x00AE
+    name: 'Omegawave Oy'
+
+  - value: 0x00AD
+    name: 'Peter Systemtechnik GmbH'
+
+  - value: 0x00AC
+    name: 'Green Throttle Games'
+
+  - value: 0x00AB
+    name: 'Ingenieur-Systemgruppe Zahn GmbH'
+
+  - value: 0x00AA
+    name: 'CAEN RFID srl'
+
+  - value: 0x00A9
+    name: 'MARELLI EUROPE S.P.A.'
+
+  - value: 0x00A8
+    name: 'ARP Devices Limited'
+
+  - value: 0x00A7
+    name: 'Visteon Corporation'
+
+  - value: 0x00A6
+    name: 'Panda Ocean Inc.'
+
+  - value: 0x00A5
+    name: 'OTL Dynamics LLC'
+
+  - value: 0x00A4
+    name: 'LINAK A/S'
+
+  - value: 0x00A3
+    name: 'Meta Watch Ltd.'
+
+  - value: 0x00A2
+    name: 'Vertu Corporation Limited'
+
+  - value: 0x00A1
+    name: 'SR-Medizinelektronik'
+
+  - value: 0x00A0
+    name: 'Kensington Computer Products Group'
+
+  - value: 0x009F
+    name: 'Suunto Oy'
+
+  - value: 0x009E
+    name: 'Bose Corporation'
+
+  - value: 0x009D
+    name: 'Geoforce Inc.'
+
+  - value: 0x009C
+    name: 'Colorfy, Inc.'
+
+  - value: 0x009B
+    name: 'Jiangsu Toppower Automotive Electronics Co., Ltd.'
+
+  - value: 0x009A
+    name: 'Alpwise'
+
+  - value: 0x0099
+    name: 'i.Tech Dynamic Global Distribution Ltd.'
+
+  - value: 0x0098
+    name: 'zero1.tv GmbH'
+
+  - value: 0x0097
+    name: 'ConnecteDevice Ltd.'
+
+  - value: 0x0096
+    name: 'ODM Technology, Inc.'
+
+  - value: 0x0095
+    name: 'NEC Lighting, Ltd.'
+
+  - value: 0x0094
+    name: 'Airoha Technology Corp.'
+
+  - value: 0x0093
+    name: 'Universal Electronics, Inc.'
+
+  - value: 0x0092
+    name: 'ThinkOptics, Inc.'
+
+  - value: 0x0091
+    name: 'Advanced PANMOBIL systems GmbH & Co. KG'
+
+  - value: 0x0090
+    name: 'Funai Electric Co., Ltd.'
+
+  - value: 0x008F
+    name: 'Telit Wireless Solutions GmbH'
+
+  - value: 0x008E
+    name: 'Quintic Corp'
+
+  - value: 0x008D
+    name: 'Zscan Software'
+
+  - value: 0x008C
+    name: 'Gimbal Inc.'
+
+  - value: 0x008B
+    name: 'Topcon Positioning Systems, LLC'
+
+  - value: 0x008A
+    name: 'Jawbone'
+
+  - value: 0x0089
+    name: 'GN Hearing A/S'
+
+  - value: 0x0088
+    name: 'Ecotest'
+
+  - value: 0x0087
+    name: 'Garmin International, Inc.'
+
+  - value: 0x0086
+    name: 'Equinux AG'
+
+  - value: 0x0085
+    name: 'BlueRadios, Inc.'
+
+  - value: 0x0084
+    name: 'Ludus Helsinki Ltd.'
+
+  - value: 0x0083
+    name: 'TimeKeeping Systems, Inc.'
+
+  - value: 0x0082
+    name: 'DSEA A/S'
+
+  - value: 0x0081
+    name: 'WuXi Vimicro'
+
+  - value: 0x0080
+    name: 'DeLorme Publishing Company, Inc.'
+
+  - value: 0x007F
+    name: 'Autonet Mobile'
+
+  - value: 0x007E
+    name: 'Sports Tracking Technologies Ltd.'
+
+  - value: 0x007D
+    name: 'Seers Technology Co., Ltd.'
+
+  - value: 0x007C
+    name: 'A & R Cambridge'
+
+  - value: 0x007B
+    name: 'Hanlynn Technologies'
+
+  - value: 0x007A
+    name: 'MStar Semiconductor, Inc.'
+
+  - value: 0x0079
+    name: 'lesswire AG'
+
+  - value: 0x0078
+    name: 'Nike, Inc.'
+
+  - value: 0x0077
+    name: 'Laird Connectivity LLC'
+
+  - value: 0x0076
+    name: 'Creative Technology Ltd.'
+
+  - value: 0x0075
+    name: 'Samsung Electronics Co. Ltd.'
+
+  - value: 0x0074
+    name: 'Zomm, LLC'
+
+  - value: 0x0073
+    name: 'Group Sense Ltd.'
+
+  - value: 0x0072
+    name: 'ShangHai Super Smart Electronics Co. Ltd.'
+
+  - value: 0x0071
+    name: 'connectBlue AB'
+
+  - value: 0x0070
+    name: 'Monster, LLC'
+
+  - value: 0x006F
+    name: 'Sound ID'
+
+  - value: 0x006E
+    name: 'Summit Data Communications, Inc.'
+
+  - value: 0x006D
+    name: 'BriarTek, Inc'
+
+  - value: 0x006C
+    name: 'Beautiful Enterprise Co., Ltd.'
+
+  - value: 0x006B
+    name: 'Polar Electro OY'
+
+  - value: 0x006A
+    name: 'LTIMINDTREE LIMITED'
+
+  - value: 0x0069
+    name: 'A&D Engineering, Inc.'
+
+  - value: 0x0068
+    name: 'General Motors'
+
+  - value: 0x0067
+    name: 'GN Hearing'
+
+  - value: 0x0066
+    name: '9Solutions Oy'
+
+  - value: 0x0065
+    name: 'HP, Inc.'
+
+  - value: 0x0064
+    name: 'Band XI International, LLC'
+
+  - value: 0x0063
+    name: 'MiCommand Inc.'
+
+  - value: 0x0062
+    name: 'Gibson Guitars'
+
+  - value: 0x0061
+    name: 'RDA Microelectronics'
+
+  - value: 0x0060
+    name: 'RivieraWaves S.A.S'
+
+  - value: 0x005F
+    name: 'Wicentric, Inc.'
+
+  - value: 0x005E
+    name: 'Stonestreet One, LLC'
+
+  - value: 0x005D
+    name: 'Realtek Semiconductor Corporation'
+
+  - value: 0x005C
+    name: 'Belkin International, Inc.'
+
+  - value: 0x005B
+    name: 'Ralink Technology Corporation'
+
+  - value: 0x005A
+    name: 'EM Microelectronic-Marin SA'
+
+  - value: 0x0059
+    name: 'Nordic Semiconductor ASA'
+
+  - value: 0x0058
+    name: 'Vizio, Inc.'
+
+  - value: 0x0057
+    name: 'Harman International Industries, Inc.'
+
+  - value: 0x0056
+    name: 'Sony Ericsson Mobile Communications'
+
+  - value: 0x0055
+    name: 'Plantronics, Inc.'
+
+  - value: 0x0054
+    name: '3DiJoy Corporation'
+
+  - value: 0x0053
+    name: 'Free2move AB'
+
+  - value: 0x0052
+    name: 'J&M Corporation'
+
+  - value: 0x0051
+    name: 'Tzero Technologies, Inc.'
+
+  - value: 0x0050
+    name: 'SiRF Technology, Inc.'
+
+  - value: 0x004F
+    name: 'APT Ltd.'
+
+  - value: 0x004E
+    name: 'Avago Technologies'
+
+  - value: 0x004D
+    name: 'Staccato Communications, Inc.'
+
+  - value: 0x004C
+    name: 'Apple, Inc.'
+
+  - value: 0x004B
+    name: 'Continental Automotive Systems'
+
+  - value: 0x004A
+    name: 'Accel Semiconductor Ltd.'
+
+  - value: 0x0049
+    name: '3DSP Corporation'
+
+  - value: 0x0048
+    name: 'Marvell Technology Group Ltd.'
+
+  - value: 0x0047
+    name: 'Bluegiga'
+
+  - value: 0x0046
+    name: 'MediaTek, Inc.'
+
+  - value: 0x0045
+    name: 'Atheros Communications, Inc.'
+
+  - value: 0x0044
+    name: 'Socket Mobile'
+
+  - value: 0x0043
+    name: 'PARROT AUTOMOTIVE SAS'
+
+  - value: 0x0042
+    name: 'CONWISE Technology Corporation Ltd'
+
+  - value: 0x0041
+    name: 'Integrated Silicon Solution Taiwan, Inc.'
+
+  - value: 0x0040
+    name: 'Seiko Epson Corporation'
+
+  - value: 0x003F
+    name: 'Bluetooth SIG, Inc'
+
+  - value: 0x003E
+    name: 'Systems and Chips, Inc'
+
+  - value: 0x003D
+    name: 'IPextreme, Inc.'
+
+  - value: 0x003C
+    name: 'BlackBerry Limited'
+
+  - value: 0x003B
+    name: 'Gennum Corporation'
+
+  - value: 0x003A
+    name: 'Panasonic Holdings Corporation'
+
+  - value: 0x0039
+    name: 'Integrated System Solution Corp.'
+
+  - value: 0x0038
+    name: 'Syntronix Corporation'
+
+  - value: 0x0037
+    name: 'Mobilian Corporation'
+
+  - value: 0x0036
+    name: 'Renesas Electronics Corporation'
+
+  - value: 0x0035
+    name: 'Eclipse (HQ Espana) S.L.'
+
+  - value: 0x0034
+    name: 'Computer Access Technology Corporation (CATC)'
+
+  - value: 0x0033
+    name: 'Commil Ltd'
+
+  - value: 0x0032
+    name: 'Red-M (Communications) Ltd'
+
+  - value: 0x0031
+    name: 'Synopsys, Inc.'
+
+  - value: 0x0030
+    name: 'ST Microelectronics'
+
+  - value: 0x002F
+    name: 'MewTel Technology Inc.'
+
+  - value: 0x002E
+    name: 'Norwood Systems'
+
+  - value: 0x002D
+    name: 'GCT Semiconductor'
+
+  - value: 0x002C
+    name: 'Macronix International Co. Ltd.'
+
+  - value: 0x002B
+    name: 'Tenovis'
+
+  - value: 0x002A
+    name: 'Symbol Technologies, Inc.'
+
+  - value: 0x0029
+    name: 'Hitachi Ltd'
+
+  - value: 0x0028
+    name: 'R F Micro Devices'
+
+  - value: 0x0027
+    name: 'Open Interface'
+
+  - value: 0x0026
+    name: 'C Technologies'
+
+  - value: 0x0025
+    name: 'NXP B.V.'
+
+  - value: 0x0024
+    name: 'Alcatel'
+
+  - value: 0x0023
+    name: 'WavePlus Technology Co., Ltd.'
+
+  - value: 0x0022
+    name: 'NEC Corporation'
+
+  - value: 0x0021
+    name: 'Mansella Ltd'
+
+  - value: 0x0020
+    name: 'BandSpeed, Inc.'
+
+  - value: 0x001F
+    name: 'AVM Berlin'
+
+  - value: 0x001E
+    name: 'Inventel'
+
+  - value: 0x001D
+    name: 'Qualcomm'
+
+  - value: 0x001C
+    name: 'Conexant Systems Inc.'
+
+  - value: 0x001B
+    name: 'Signia Technologies, Inc.'
+
+  - value: 0x001A
+    name: 'TTPCom Limited'
+
+  - value: 0x0019
+    name: 'Rohde & Schwarz GmbH & Co. KG'
+
+  - value: 0x0018
+    name: 'Transilica, Inc.'
+
+  - value: 0x0017
+    name: 'Newlogic'
+
+  - value: 0x0016
+    name: 'KC Technology Inc.'
+
+  - value: 0x0015
+    name: 'RTX A/S'
+
+  - value: 0x0014
+    name: 'Mitsubishi Electric Corporation'
+
+  - value: 0x0013
+    name: 'Atmel Corporation'
+
+  - value: 0x0012
+    name: 'Zeevo, Inc.'
+
+  - value: 0x0011
+    name: 'Widcomm, Inc.'
+
+  - value: 0x0010
+    name: 'Mitel Semiconductor'
+
+  - value: 0x000F
+    name: 'Broadcom Corporation'
+
+  - value: 0x000E
+    name: 'Parthus Technologies Inc.'
+
+  - value: 0x000D
+    name: 'Texas Instruments Inc.'
+
+  - value: 0x000C
+    name: 'Digianswer A/S'
+
+  - value: 0x000B
+    name: 'Silicon Wave'
+
+  - value: 0x000A
+    name: 'Qualcomm Technologies International, Ltd. (QTIL)'
+
+  - value: 0x0009
+    name: 'Infineon Technologies AG'
+
+  - value: 0x0008
+    name: 'Motorola'
+
+  - value: 0x0007
+    name: 'Lucent'
+
+  - value: 0x0006
+    name: 'Microsoft'
+
+  - value: 0x0005
+    name: '3Com'
+
+  - value: 0x0004
+    name: 'Toshiba Corp.'
+
+  - value: 0x0003
+    name: 'IBM Corp.'
+
+  - value: 0x0002
+    name: 'Intel Corp.'
+
+  - value: 0x0001
+    name: 'Nokia Mobile Phones'
+
+  - value: 0x0000
+    name: 'Ericsson AB'

--- a/custom_components/bermuda/number.py
+++ b/custom_components/bermuda/number.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
     created_devices = []  # list of devices we've already created entities for
 
     @callback
-    def device_new(address: str, scanners: list[str]) -> None:  # pylint: disable=unused-argument
+    def device_new(address: str) -> None:
         """
         Create entities for newly-found device.
 

--- a/custom_components/bermuda/util.py
+++ b/custom_components/bermuda/util.py
@@ -75,6 +75,13 @@ def mac_explode_formats(mac):
     ]
 
 
+def mac_redact(mac: str, tag: str | None = None) -> str:
+    """Remove the centre octets of a MAC and optionally replace with a tag."""
+    if tag is None:
+        tag = ":"
+    return f"{mac[:2]}::{tag}::{mac[-2:]}"
+
+
 @lru_cache(1024)
 def rssi_to_metres(rssi, ref_power=None, attenuation=None):
     """


### PR DESCRIPTION
- more efficient processing of updates
- better handling of proxies being added/removed
- improvements to naming when first adding / browsing in select devices

## User-visible / features
- feat: Shorten/redact scanner macs in configure status display
- distance_to... sensors are now created/removed in realtime as scanners come and go.
- fix: startup is now faster due to better asyncio usage

## Breaking changes
- bermuda.dump_devices service/action format has changed! If you are using this please test as many items have been restructured
- scanners dict renamed to "adverts", now keyed as device/scanner tuples

## Code changes
- clarification on processing order for metadevices
- no longer save/restore scanner list in config, now dynamically CRUD'd
- implement scanner list as properties to centralise changes
- add customisations to manufacturer lookups
- centralised name generation
- added Bluetooth Company Identifiers yaml
- switch to aiofiles for yaml imports, and place in separate task
- remove extra calls to async_update_data
- big refactoring of async_update_data to improve separation of concerns and decrease complexity
- reworking of prune_devices to avoid missing devices or creating churn
- add time check to redaction_list_update
- refactor device creation and updating to improve SOC and complexity
- change from MONOTONIC_TIME to monotonic_time_coarse
- broaden BDADDR_TYPEs and add METADEVICE_DEVICETYPES
- make BermudaDeviceScanner hashable
- make BermudaDevice hashable
- use platform constants now in core.
- change to_dict methods (and others) to avoid matching attributes by string. Improved data presentation.
- tidy up remove_config_entry_device
- use async_schedule_reload instead of immediate