### PR TITLE
chore: ren BermudaDeviceScanner to BermudaAdvert

### DIFF
--- a/custom_components/bermuda/bermuda_advert.py
+++ b/custom_components/bermuda/bermuda_advert.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
 # ruff: noqa: PLR1730
 
 
-class BermudaDeviceScanner(dict):
+class BermudaAdvert(dict):
     """
     Represents details from a scanner relevant to a specific device.
 

--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -28,7 +28,7 @@ from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
 from homeassistant.core import callback
 from homeassistant.util import slugify
 
-from .bermuda_device_scanner import BermudaDeviceScanner
+from .bermuda_advert import BermudaAdvert
 from .const import (
     _LOGGER,
     _LOGGER_SPAM_LESS,
@@ -98,7 +98,7 @@ class BermudaDevice(dict):
 
         self.area_distance: float | None = None  # how far this dev is from that area
         self.area_rssi: float | None = None  # rssi from closest scanner
-        self.area_scanner: BermudaDeviceScanner | None = None  # currently closest BermudaScanner
+        self.area_scanner: BermudaAdvert | None = None  # currently closest BermudaScanner
         self.zone: str = STATE_UNAVAILABLE  # STATE_HOME or STATE_NOT_HOME
         self.manufacturer: str | None = None
         self._hascanner: BaseHaRemoteScanner | BaseHaScanner | None = None  # HA's scanner
@@ -123,7 +123,7 @@ class BermudaDevice(dict):
         self.last_seen: float = 0  # stamp from most recent scanner spotting. monotonic_time_coarse
         self.diag_area_switch: str | None = None  # saves output of AreaTests
         self.adverts: dict[
-            tuple[str, str], BermudaDeviceScanner
+            tuple[str, str], BermudaAdvert
         ] = {}  # str will be a scanner address OR a deviceaddress__scanneraddress
         self._async_process_address_type()
 
@@ -392,7 +392,7 @@ class BermudaDevice(dict):
             # new measurement(s) immediately.
             self.ref_power_changed = monotonic_time_coarse()
 
-    def apply_scanner_selection(self, closest_scanner: BermudaDeviceScanner | None):
+    def apply_scanner_selection(self, closest_scanner: BermudaAdvert | None):
         """
         Given a DeviceScanner entry, apply the distance and area attributes
         from it to this device.
@@ -425,7 +425,7 @@ class BermudaDevice(dict):
                 self.area_name,
             )
 
-    def get_scanner(self, scanner_address) -> BermudaDeviceScanner | None:
+    def get_scanner(self, scanner_address) -> BermudaAdvert | None:
         """
         Given a scanner address, return the most recent BermudaDeviceScanner (advert) that matches.
 
@@ -451,7 +451,7 @@ class BermudaDevice(dict):
         """
         # Run calculate_data on each child scanner of this device:
         for advert in self.adverts.values():
-            if isinstance(advert, BermudaDeviceScanner):
+            if isinstance(advert, BermudaAdvert):
                 # in issue #355 someone had an empty dict instead of a scanner object.
                 # it may be due to a race condition during startup, but we check now
                 # just in case. Was not able to reproduce.
@@ -505,7 +505,7 @@ class BermudaDevice(dict):
             device_advert = self.adverts[advert_tuple]
         else:
             # Create it
-            device_advert = self.adverts[advert_tuple] = BermudaDeviceScanner(
+            device_advert = self.adverts[advert_tuple] = BermudaAdvert(
                 self,
                 advertisementdata,
                 self.options,
@@ -519,7 +519,7 @@ class BermudaDevice(dict):
         if device_advert.stamp is not None and self.last_seen < device_advert.stamp:
             self.last_seen = device_advert.stamp
 
-    def process_manufacturer_data(self, advert: BermudaDeviceScanner):
+    def process_manufacturer_data(self, advert: BermudaAdvert):
         """Parse manufacturer data for maker name and iBeacon etc."""
         # Only override existing manufacturer name if it's "better"
 

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -101,7 +101,7 @@ if TYPE_CHECKING:
     from homeassistant.components.bluetooth.manager import HomeAssistantBluetoothManager
 
     from . import BermudaConfigEntry
-    from .bermuda_device_scanner import BermudaDeviceScanner
+    from .bermuda_advert import BermudaAdvert
 
 Cancellable = Callable[[], None]
 
@@ -1303,7 +1303,7 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
     def _refresh_area_by_min_distance(self, device: BermudaDevice):
         """Very basic Area setting by finding closest proxy to a given device."""
         # The current area_scanner (which might be None) is the one to beat.
-        closest_advert: BermudaDeviceScanner | None = device.area_scanner
+        closest_advert: BermudaAdvert | None = device.area_scanner
 
         _max_radius = self.options.get(CONF_MAX_RADIUS, DEFAULT_MAX_RADIUS)
         nowstamp = monotonic_time_coarse()


### PR DESCRIPTION
More accurately represents the class, which is the advertisement that ties a device and scanner together.