### PR TITLE
fix: redactions in irk_manager diagnostics

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -287,9 +287,10 @@ class BermudaDevice(dict):
         if scannerstamp > self.last_seen:
             self.last_seen = scannerstamp
         elif self.last_seen - scannerstamp > 0.8:  # For some reason small future-offsets are common.
-            _LOGGER.warning(
-                "Scanner stamps for %s should not go backwards. new %f < last %f",
+            _LOGGER.debug(
+                "Scanner stamp for %s went backwards %.2fs. new %f < last %f",
                 self.name,
+                self.last_seen - scannerstamp,
                 scannerstamp,
                 self.last_seen,
             )

--- a/custom_components/bermuda/bermuda_irk.py
+++ b/custom_components/bermuda/bermuda_irk.py
@@ -217,13 +217,17 @@ class BermudaIrkManager:
 
         return _unsubscribe
 
-    def async_diagnostics(self):
+    def async_diagnostics_no_redactions(self):
         """Return diagnostic info. Make sure to run redactions over the results."""
         nowstamp = monotonic_time_coarse()
         macs = {}
         for macirk in self._macs.values():
             if macirk.irk not in [IrkTypes.ADRESS_NOT_EVALUATED.value, IrkTypes.NOT_RESOLVABLE_ADDRESS.value]:
-                macs[macirk.mac] = {"irk": macirk.irk, "expires_in": floor(macirk.expires - nowstamp)}
+                if macirk.irk == IrkTypes.NO_KNOWN_IRK_MATCH.value:
+                    irkout = IrkTypes.NO_KNOWN_IRK_MATCH.name
+                else:
+                    irkout = macirk.irk.hex()
+                macs[macirk.mac] = {"irk": irkout, "expires_in": floor(macirk.expires - nowstamp)}
 
         return {
             "irks": [irk.hex() for irk in self._irks],

--- a/custom_components/bermuda/diagnostics.py
+++ b/custom_components/bermuda/diagnostics.py
@@ -28,7 +28,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: Bermuda
     data: dict[str, Any] = {
         "active_devices": f"{coordinator.count_active_devices()}/{len(coordinator.devices)}",
         "active_scanners": f"{coordinator.count_active_scanners()}/{len(coordinator.scanner_list)}",
-        "irk_manager": coordinator.irk_manager.async_diagnostics(),
+        "irk_manager": coordinator.redact_data(coordinator.irk_manager.async_diagnostics_no_redactions()),
         "devices": await coordinator.service_dump_devices(call),
         "bt_manager": coordinator.redact_data(bt_diags),
     }

--- a/custom_components/bermuda/util.py
+++ b/custom_components/bermuda/util.py
@@ -61,18 +61,16 @@ def mac_norm(mac: str) -> str:
 
 
 @lru_cache(2048)
-def mac_explode_formats(mac):
+def mac_explode_formats(mac) -> set[str]:
     """
     Take a formatted mac address and return the formats
-    likely to be found in our device info, adverts etc.
+    likely to be found in our device info, adverts etc
+    by replacing ":" with each of "", "-", "_", ".".
     """
-    return [
-        mac,
-        mac.replace(":", ""),
-        mac.replace(":", "-"),
-        mac.replace(":", "_"),
-        mac.replace(":", "."),
-    ]
+    altmacs = set(mac)
+    for newsep in ["", "-", "_", "."]:
+        altmacs.add(mac.replace(":", newsep))
+    return altmacs
 
 
 def mac_redact(mac: str, tag: str | None = None) -> str:


### PR DESCRIPTION
The irk_manager introduced in v0.8.2beta3 did not redact the irk and MAC addresses collected for diagnostics. This is now fixed.
- improved performance of redact_data by moving mac format expansions into redaction_list_update and correcting logic
- quieted debug logger on metaNoAdsFor / "Metadevice .. no adverts for source MAC .. found during update_metadevices"
- quieted "scanner stamps for .. should not go backwards" to debug fixes #580