### PR TITLE
fix: mac_explode, move redaction purge to pruning

### DIFF
--- a/custom_components/bermuda/__init__.py
+++ b/custom_components/bermuda/__init__.py
@@ -46,7 +46,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BermudaConfigEntry) -> b
 
     async def on_failure():
         _LOGGER.debug("Coordinator last update failed, rasing ConfigEntryNotReady")
-        await coordinator.stop_purging()
         raise ConfigEntryNotReady
 
     try:
@@ -133,7 +132,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: BermudaConfigEntry) -> 
     """Handle removal of an entry."""
     if unload_result := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         _LOGGER.debug("Unloaded platforms.")
-    await entry.runtime_data.coordinator.stop_purging()
     return unload_result
 
 

--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -138,6 +138,8 @@ PRUNE_TIME_UNKNOWN_IRK = 240  # Resolvable Private addresses change often, prune
 # see Bluetooth Core Spec, Vol3, Part C, Appendix A, Table A.1: Defined GAP timers
 PRUNE_TIME_KNOWN_IRK: Final[int] = 16 * 60  # spec "recommends" 15 min max address age. Round up to 16 :-)
 
+PRUNE_TIME_REDACTIONS: Final[int] = 10 * 60  # when to discard redaction data
+
 SAVEOUT_COOLDOWN = 10  # seconds to delay before re-trying config entry save.
 
 DOCS = {}

--- a/custom_components/bermuda/util.py
+++ b/custom_components/bermuda/util.py
@@ -61,13 +61,14 @@ def mac_norm(mac: str) -> str:
 
 
 @lru_cache(2048)
-def mac_explode_formats(mac) -> set[str]:
+def mac_explode_formats(mac: str) -> set[str]:
     """
     Take a formatted mac address and return the formats
     likely to be found in our device info, adverts etc
     by replacing ":" with each of "", "-", "_", ".".
     """
-    altmacs = set(mac)
+    altmacs = set()
+    altmacs.add(mac)
     for newsep in ["", "-", "_", "."]:
         altmacs.add(mac.replace(":", newsep))
     return altmacs


### PR DESCRIPTION
- Fixed a very silly bug in mac_explode_formats that exploded too much (to individual chars!)
- Redaction purge was using a separate task for clearing redaction_data which added compexity. Changed to use device pruning instead to bring it into the regular loop and reduced expiry time to 10 mins instead of hours.