### PR TITLE
feat: initial floors support

### DIFF
--- a/custom_components/bermuda/const.py
+++ b/custom_components/bermuda/const.py
@@ -26,7 +26,8 @@ ISSUE_URL = "https://github.com/agittins/bermuda/issues"
 
 # Icons
 ICON = "mdi:format-quote-close"
-
+ICON_DEFAULT_AREA: Final = "mdi:land-plots-marker"
+ICON_DEFAULT_FLOOR: Final = "mdi:selection-marker"  # "mdi:floor-plan"
 # Issue/repair translation keys. If you change these you MUST also update the key in the translations/xx.json files.
 REPAIR_SCANNER_WITHOUT_AREA = "scanner_without_area"
 

--- a/custom_components/bermuda/device_tracker.py
+++ b/custom_components/bermuda/device_tracker.py
@@ -82,7 +82,7 @@ class BermudaDeviceTracker(BermudaEntity, BaseTrackerEntity):
     @property
     def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return extra state attributes for this device."""
-        _scannername = self._device.area_scanner.name if self._device.area_scanner is not None else None
+        _scannername = self._device.area_advert.name if self._device.area_advert is not None else None
         return {"scanner": _scannername, "area": self._device.area_name}
 
     @property

--- a/custom_components/bermuda/entity.py
+++ b/custom_components/bermuda/entity.py
@@ -46,8 +46,8 @@ class BermudaEntity(CoordinatorEntity):
         self.address = address
         self._device = coordinator.devices[address]
         self._lastname = self._device.name  # So we can track when we get a new name
-        self.area_reg = ar.async_get(coordinator.hass)
-        self.devreg = dr.async_get(coordinator.hass)
+        self.ar = ar.async_get(coordinator.hass)
+        self.dr = dr.async_get(coordinator.hass)
         self.devreg_init_done = False
 
         self.bermuda_update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
@@ -97,7 +97,7 @@ class BermudaEntity(CoordinatorEntity):
             self._lastname = self._device.name
             if self.device_entry:
                 # We have a new name locally, so let's update the device registry.
-                self.devreg.async_update_device(self.device_entry.id, name=self._device.name)
+                self.dr.async_update_device(self.device_entry.id, name=self._device.name)
         self.async_write_ha_state()
 
     @property


### PR DESCRIPTION
- basic floor support. Uses area_id to directly map to current floor.
- Floor sensors are automatically enabled at startup if any area is
  assigned to any floor.
- attributes on the floor entity give access to floor_id and floor_level
- icons for Floor sensors also take the floor icon if set.

Signed-off-by: Ashley Gittins <ash@ajg.net.au>