### PR TITLE
Lower logging level for unexpected stamps

### DIFF
--- a/custom_components/bermuda/bermuda_advert.py
+++ b/custom_components/bermuda/bermuda_advert.py
@@ -131,7 +131,7 @@ class BermudaAdvert(dict):
         # exit quickly if that's the case (ideally we will catch it earlier in future)
         #
         if scanner_device is not self.scanner_device:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Replacing stale scanner device %s with %s", self.scanner_device.__repr__(), scanner_device.__repr__()
             )
             self.apply_new_scanner(scanner_device)
@@ -144,13 +144,13 @@ class BermudaAdvert(dict):
 
             if new_stamp is None:
                 self.stale_update_count += 1
-                _LOGGER.warning("Advert from %s for %s lacks stamp, unexpected.", scanner.name, self._device.name)
+                _LOGGER.debug("Advert from %s for %s lacks stamp, unexpected.", scanner.name, self._device.name)
                 return
 
             if self.stamp > new_stamp:
                 # The existing stamp is NEWER, bail but complain on the way.
                 self.stale_update_count += 1
-                _LOGGER.warning("Advert from %s for %s is OLDER than last recorded", scanner.name, self._device.name)
+                _LOGGER.debug("Advert from %s for %s is OLDER than last recorded", scanner.name, self._device.name)
                 return
 
             if self.stamp == new_stamp:
@@ -168,7 +168,7 @@ class BermudaAdvert(dict):
 
         # Update our parent scanner's last_seen if we have a new stamp.
         if new_stamp > self.scanner_device.last_seen + 0.01:  # some slight warp seems common.
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Advert from %s for %s is %.6fs NEWER than scanner's last_seen, odd",
                 self.scanner_device.name,
                 self._device.name,

--- a/custom_components/bermuda/bermuda_irk.py
+++ b/custom_components/bermuda/bermuda_irk.py
@@ -189,7 +189,7 @@ class BermudaIrkManager:
 
         # HA version when BLEDevice went from 4+ params to 3 (bleak 1.0.0, 1.0.1)
         if MAJOR_VERSION > 2025 or (MAJOR_VERSION == 2025 and MINOR_VERSION >= 8):
-            bledevice = BLEDevice(mac, "", None)
+            bledevice = BLEDevice(mac, "", None)  # type: ignore
         else:
             # Include the rssi if we are on an older release.
             bledevice = BLEDevice(mac, "", None, 0)  # type: ignore


### PR DESCRIPTION
- Various stamp-checking log lines have been reduced from warning or info to debug.
- Includes "lacks stamp, unexpected", noted in #584
- disabled typecheck on BLEDevice call, for linting.