### PR TITLE
fix: Lower logging re ex-scanners fixes #608

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -718,10 +718,12 @@ class BermudaDevice(dict):
         advert_tuple = (device_address, scanner_address)
 
         if len(self.metadevice_sources) > 0 and not self._is_scanner:
-            # If we're a metadevice we should never be in this function.
-            _LOGGER_SPAM_LESS.error(
+            # If we're a metadevice we should never be in this function,
+            # unless we _used_ to be a scanner but are no longer. Shelly proxies
+            # seem to do this when they go offline. See #608
+            _LOGGER_SPAM_LESS.debug(
                 f"meta_{self.address}_{advert_tuple}",
-                "Calling process_advertisement on a metadevice (%s) is a bug. Advert tuple: (%s)",
+                "process_advertisement called on a metadevice (%s) - probably a dead proxy. Advert tuple: (%s)",
                 self.__repr__(),
                 advert_tuple,
             )


### PR DESCRIPTION
The "Calling process_advertisement on a metadevice [] is a bug" log message turns out to be a bug. Some proxies (certainly Shellys) will sometimes trigger this if they drop off the network or restart, where `is_scanner` is set to false and the extra mac address (to account for wifi,ether,ap,ble macs) is still in `metadevice_sources`.

This patch just moves the message to debug logging only, since it's not relevant for end-users.