### PR TITLE
Fix ValueError when processing device identifiers with 3+ elements

### DIFF
--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -438,7 +438,11 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
                         # this was probably us, nothing else to do
                         pass
                     else:
-                        for ident_type, ident_id in device_entry.identifiers:
+                        for identifier in device_entry.identifiers:
+                            if len(identifier) >= 2:
+                                ident_type, ident_id = identifier[0], identifier[1]
+                            else:
+                                continue
                             if ident_type == DOMAIN:
                                 # One of our sensor devices!
                                 try:


### PR DESCRIPTION
## Summary
Fixes a ValueError that occurs when processing device registry updates for devices with identifiers containing more than 2 elements (e.g., HomeKit devices use 3-element identifiers).

## Problem
The current code assumes all device identifiers are 2-tuples `(domain, id)`, but some integrations like HomeKit use 3-element identifiers `(domain, id, type)`. This causes `ValueError: too many values to unpack (expected 2)` when those devices trigger registry updates.

## Solution
Changed the unpacking to iterate over identifiers and safely extract the first two elements regardless of total length.

### Before
```python
for ident_type, ident_id in device_entry.identifiers:
```

### After
```python
for identifier in device_entry.identifiers:
    if len(identifier) >= 2:
        ident_type, ident_id = identifier[0], identifier[1]
    else:
        continue
```