### PR TITLE
Skip malformed device identifiers in handle_devreg_changes

### DIFF
--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -438,7 +438,20 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
                         # this was probably us, nothing else to do
                         pass
                     else:
-                        for ident_type, ident_id in device_entry.identifiers:
+                        for identifier in device_entry.identifiers:
+                            # HA device identifiers are expected to be
+                            # (domain, id) tuples, but a buggy integration can
+                            # register a malformed one (e.g. a bare string that
+                            # unpacks into many values). Skip those rather than
+                            # letting a ValueError crash the whole handler.
+                            if len(identifier) != 2:
+                                _LOGGER.debug(
+                                    "Ignoring malformed device identifier on %s: %s",
+                                    ev.data["device_id"],
+                                    identifier,
+                                )
+                                continue
+                            ident_type, ident_id = identifier
                             if ident_type == DOMAIN:
                                 # One of our sensor devices!
                                 try:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,50 @@
+"""Tests for BermudaDataUpdateCoordinator."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.bermuda.coordinator import BermudaDataUpdateCoordinator
+
+
+def test_handle_devreg_malformed_identifier():
+    """A malformed device identifier must not crash the devreg handler.
+
+    Regression test: Home Assistant device identifiers are expected to be
+    ``(domain, id)`` 2-tuples, but a buggy integration can register a
+    malformed one (observed in the wild: a Plejd device whose id string was
+    stored as many single-character elements). Bermuda unpacked every
+    identifier directly, so such a device raised
+    ``ValueError: too many values to unpack`` and broke the entire
+    ``device_registry_updated`` handler on every registry change.
+
+    The handler must skip malformed identifiers, still process valid ones,
+    and run to completion.
+    """
+    # A device with a non-Bermuda connection (so we reach the identifier
+    # branch), one malformed identifier and one valid Bermuda identifier.
+    device_entry = SimpleNamespace(
+        connections={("mac", "AA:BB:CC:DD:EE:FF")},
+        identifiers={
+            ("plejd", "D", "8", "9", "D", "F", "D", "A"),  # malformed: not a 2-tuple
+            ("bermuda", "aa:bb:cc:dd:ee:ff"),  # valid (domain, id)
+        },
+        name_by_user=None,
+    )
+
+    # Lightweight stand-in for the coordinator; we invoke the real (unbound)
+    # handler with it as ``self`` to avoid setting up the full integration.
+    coordinator = SimpleNamespace(
+        devices={},
+        dr=SimpleNamespace(async_get=lambda device_id: device_entry),
+        _scanner_init_pending=False,
+        _do_private_device_init=False,
+    )
+
+    event = SimpleNamespace(data={"action": "update", "device_id": "malformed-device", "changes": {}})
+
+    # Previously raised ValueError: too many values to unpack (expected 2).
+    BermudaDataUpdateCoordinator.handle_devreg_changes(coordinator, event)
+
+    # Reached the end of the identifier branch without raising.
+    assert coordinator._scanner_init_pending is True


### PR DESCRIPTION
## Problem

`BermudaDataUpdateCoordinator.handle_devreg_changes` unpacks every device identifier directly:

```python
for ident_type, ident_id in device_entry.identifiers:
```

Home Assistant device identifiers are *expected* to be `(domain, id)` 2-tuples, but a buggy integration can register a malformed one. In my setup the **Plejd** integration registered a device whose id string was stored as many single-character elements, e.g.:

```
('plejd', 'D', '8', '9', 'D', 'F', 'D', 'A', '6', '6', '1', '1', 'C', ':', ...)   # 24 elements
```

Because Bermuda listens to *every* `device_registry_updated` event, this raised on each registry change and broke the whole handler:

```
Error running job: ... BermudaDataUpdateCoordinator.handle_devreg_changes ...
  File ".../custom_components/bermuda/coordinator.py", line 441, in handle_devreg_changes
    for ident_type, ident_id in device_entry.identifiers:
ValueError: too many values to unpack (expected 2, got 24)
```

The error fires on every restart / registry update. Bermuda itself is only the messenger here (the root cause is the other integration's bad data), but one misbehaving integration shouldn't be able to break Bermuda's device-registry handling.

## Fix

Guard the unpack: skip identifiers that aren't 2-tuples (logging at `debug`) and keep processing the valid ones.

## Test

Adds `tests/test_coordinator.py::test_handle_devreg_malformed_identifier`, a lightweight unit test that drives `handle_devreg_changes` with a device carrying one malformed and one valid identifier. Verified it fails with `ValueError: too many values to unpack (expected 2, got 8)` on `main` and passes with this change.

> Note: I ran the new test locally against HA 2026.7.2. It passes. The autouse bluetooth fixture emits an unrelated scanner-teardown error in my throwaway env (same for pre-existing tests like `test_bermuda_device::test_make_name`), so I've left CI to run the full suite.