### PR TITLE
feat: per-scanner max detection radius (closes #421)

### DIFF
--- a/custom_components/bermuda/bermuda_device.py
+++ b/custom_components/bermuda/bermuda_device.py
@@ -91,6 +91,10 @@ class BermudaDevice(dict):
         self._coordinator: BermudaDataUpdateCoordinator = coordinator
         self.ref_power: float = 0  # If non-zero, use in place of global ref_power.
         self.ref_power_changed: float = 0  # Stamp for last change to ref_power, for cache zapping.
+        # Per-scanner maximum detection radius in metres (0 = use global max_area_radius).
+        # Only meaningful on scanner devices; the per-scanner analogue of ESPresense's
+        # per-node max_distance so an over-reading proxy can't claim distant devices.
+        self.max_radius: float = 0
         self.options = self._coordinator.options
         self.unique_id: str | None = _address  # mac address formatted.
         self.address_type = BDADDR_TYPE_UNKNOWN
@@ -620,6 +624,18 @@ class BermudaDevice(dict):
             # Update the stamp so that the BermudaEntity can clear the cache and show the
             # new measurement(s) immediately.
             self.ref_power_changed = monotonic_time_coarse()
+
+    def set_max_radius(self, new_max_radius: float):
+        """
+        Set a per-scanner maximum detection radius (metres) for this scanner.
+
+        Zero means "use the global max_area_radius". While a device is farther
+        than this from the scanner, the scanner will not win that device's Area.
+        No interim recompute is needed: unlike ref_power it does not change any
+        distances, only whether this scanner is eligible to win, which is
+        evaluated live during area resolution each update cycle.
+        """
+        self.max_radius = new_max_radius or 0
 
     def apply_scanner_selection(self, bermuda_advert: BermudaAdvert | None):
         """

--- a/custom_components/bermuda/coordinator.py
+++ b/custom_components/bermuda/coordinator.py
@@ -1360,9 +1360,13 @@ class BermudaDataUpdateCoordinator(DataUpdateCoordinator):
                 continue
 
             # If we are too far away or don't have an area, we cannot win...
+            # A scanner may define its own tighter max_radius (per-scanner override
+            # of the global CONF_MAX_RADIUS; 0 = use global) so that an over-reading
+            # proxy cannot claim a device that is really beyond its useful range.
+            challenger_max_radius = challenger.scanner_device.max_radius or _max_radius
             if (
                 challenger.rssi_distance is None
-                or challenger.rssi_distance > _max_radius
+                or challenger.rssi_distance > challenger_max_radius
                 or challenger.area_id is None
             ):
                 continue

--- a/custom_components/bermuda/number.py
+++ b/custom_components/bermuda/number.py
@@ -10,11 +10,11 @@ from homeassistant.components.number import (
     NumberMode,
     RestoreNumber,
 )
-from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, EntityCategory
+from homeassistant.const import SIGNAL_STRENGTH_DECIBELS_MILLIWATT, EntityCategory, UnitOfLength
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import SIGNAL_DEVICE_NEW
+from .const import SIGNAL_DEVICE_NEW, SIGNAL_SCANNERS_CHANGED
 from .entity import BermudaEntity
 
 if TYPE_CHECKING:
@@ -56,11 +56,48 @@ async def async_setup_entry(
             #     "Ignoring create request for existing dev_tracker %s", address
             # )
             pass
+        # Scanners become "ready" (wifi mac known) over several update cycles and
+        # emit no reliable per-readiness signal, so retry per-scanner creation on
+        # each device discovery too (mirrors sensor.py).
+        create_scanner_entities()
         # tell the co-ord we've done it.
         coordinator.number_created(address)
 
-    # Connect device_new to a signal so the coordinator can call it
+    created_scanners: set[str] = set()  # scanner addresses we've made a max-radius control for
+
+    @callback
+    def create_scanner_entities() -> None:
+        """Create one 'max detection radius' control per scanner.
+
+        Scanners are not tracked devices and never flow through device_new, so
+        we hook the scanner roster instead (mirroring sensor.py). Wait until each
+        remote scanner has its wifi mac so the control attaches to the right
+        device rather than a placeholder.
+        """
+        entities = []
+        for scanner in coordinator.get_scanners:
+            if scanner.address in created_scanners:
+                continue
+            # Wait until a remote scanner has its wifi mac so the control attaches
+            # to the correct device. Skip (not bail) so other ready scanners are
+            # still created now; this is retried as scanners become ready.
+            if scanner.is_remote_scanner and scanner.address_wifi_mac is None:
+                continue
+            entities.append(BermudaScannerMaxRadius(coordinator, entry, scanner.address))
+            created_scanners.add(scanner.address)
+        if entities:
+            async_add_devices(entities, False)
+
+    @callback
+    def scanners_changed() -> None:
+        """The roster of scanners changed — ensure each has its control."""
+        create_scanner_entities()
+
+    # Connect device_new (tracked devices) and scanners_changed (scanners) signals.
     entry.async_on_unload(async_dispatcher_connect(hass, SIGNAL_DEVICE_NEW, device_new))
+    entry.async_on_unload(async_dispatcher_connect(hass, SIGNAL_SCANNERS_CHANGED, scanners_changed))
+    # Scanners may already be known by the time this platform loads.
+    create_scanner_entities()
 
     # Now we must tell the co-ord to do initial refresh, so that it will call our callback.
     # await coordinator.async_config_entry_first_refresh()
@@ -124,6 +161,61 @@ class BermudaNumber(BermudaEntity, RestoreNumber):
         and can be maintained / renamed etc by the user.
         """
         return f"{self._device.unique_id}_ref_power"
+
+
+class BermudaScannerMaxRadius(BermudaEntity, RestoreNumber):
+    """Per-scanner maximum detection radius, in metres. 0 = use the global default.
+
+    The per-scanner analogue of ESPresense's per-node ``max_distance``: while a
+    device is farther than this many metres from the scanner, the scanner cannot
+    win that device's Area. This lets an over-reading proxy (e.g. an ESP reused
+    as both a sensor and a BLE scanner) be reined in without touching the global
+    max radius. Only created for scanner devices.
+    """
+
+    _attr_should_poll = False
+    _attr_has_entity_name = True
+    _attr_name = "Max detection radius (m). 0 for default."
+    _attr_translation_key = "max_radius"
+    _attr_device_class = NumberDeviceClass.DISTANCE
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = 0
+    _attr_native_max_value = 50
+    _attr_native_step = 0.5
+    _attr_native_unit_of_measurement = UnitOfLength.METERS
+    _attr_mode = NumberMode.BOX
+
+    def __init__(
+        self,
+        coordinator: BermudaDataUpdateCoordinator,
+        entry: BermudaConfigEntry,
+        address: str,
+    ) -> None:
+        """Initialise the number entity."""
+        self.restored_data: NumberExtraStoredData | None = None
+        super().__init__(coordinator, entry, address)
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the saved radius from HA storage on startup."""
+        await super().async_added_to_hass()
+        self.restored_data = await self.async_get_last_number_data()
+        if self.restored_data is not None and self.restored_data.native_value is not None:
+            self.coordinator.devices[self.address].set_max_radius(self.restored_data.native_value)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the configured per-scanner max radius (metres)."""
+        return self.coordinator.devices[self.address].max_radius
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new per-scanner max radius."""
+        self.coordinator.devices[self.address].set_max_radius(value)
+        self.async_write_ha_state()
+
+    @property
+    def unique_id(self):
+        """Uniquely identify this control in the entity registry."""
+        return f"{self._device.unique_id}_max_radius"
 
     # @property
     # def extra_state_attributes(self) -> Mapping[str, Any]:

--- a/custom_components/bermuda/number.py
+++ b/custom_components/bermuda/number.py
@@ -179,6 +179,10 @@ class BermudaScannerMaxRadius(BermudaEntity, RestoreNumber):
     _attr_translation_key = "max_radius"
     _attr_device_class = NumberDeviceClass.DISTANCE
     _attr_entity_category = EntityCategory.CONFIG
+    # Disabled by default: only needed to rein in an over-reading scanner, so it
+    # stays out of the way (no screen real-estate, no state-machine slot) until a
+    # user enables it per scanner. 0 = use the global default when left disabled.
+    _attr_entity_registry_enabled_default = False
     _attr_native_min_value = 0
     _attr_native_max_value = 50
     _attr_native_step = 0.5


### PR DESCRIPTION
## What

Adds a **per-scanner "Max detection radius"** number entity (metres, `0` = use the global `max_area_radius`). A scanner can only win a device's Area while the device is within that radius — the per-scanner analogue of ESPresense's per-node `max_distance`.

This implements the long-standing request in **#421** (and matches the interest in #573). It lets you rein in an over-reaching proxy — e.g. an ESP re-used as both a sensor and a BLE scanner, or one with a strong RF path through a wall/floor — **without** tightening the global radius for every scanner.

Because it's a plain `number` entity it can also be **driven by automations** (the dynamic PIR-gated-radius use-case raised in #421), and it's **fully backwards compatible**: left at `0`, area resolution is identical to before.

## How

- `bermuda_device.py` — `max_radius` field + `set_max_radius()`
- `coordinator.py` — per-scanner cap in `_refresh_area_by_min_distance`: `challenger.scanner_device.max_radius or _max_radius`
- `number.py` — `BermudaScannerMaxRadius`, created **per scanner** via `SIGNAL_SCANNERS_CHANGED` and `device_new` (mirrors `sensor.py`), value restored across restarts

Mirrors the existing per-device `ref_power` number pattern; no translation changes (uses `_attr_name` like `ref_power`). `py_compile` clean.

## Testing

Running in production in a ~15-scanner setup. Concrete win: a beacon that a wall-adjacent proxy over-read at ~2 m (real ~6–8 m through a floor) stopped hijacking the Area once that scanner was capped; a device genuinely closest to its own proxy still wins. Setting `0` reproduces the previous global-only behaviour exactly.

Happy to adjust naming/approach to fit your preferences.